### PR TITLE
error handling screen

### DIFF
--- a/src/app/identity.rs
+++ b/src/app/identity.rs
@@ -14,21 +14,11 @@ use dpp::platform_value::string_encoding::Encoding;
 use dpp::prelude::Identifier;
 use dpp::{prelude::Identity, serialization::PlatformDeserializable};
 use rs_dapi_client::{DapiClient, DapiRequest, RequestSettings};
-use tuirealm::props::{PropValue, TextSpan};
 
-pub(super) fn identity_bytes_to_spans(bytes: &[u8]) -> Result<Vec<PropValue>, Error> {
-    let identity = Identity::deserialize_from_bytes(&bytes)?;
-    let textual = toml::to_string_pretty(&identity).expect("identity is serializable");
-    Ok(textual
-        .lines()
-        .map(|line| PropValue::TextSpan(TextSpan::new(line)))
-        .collect())
-}
-
-pub(super) async fn fetch_identity_bytes_by_b58_id(
+pub(super) async fn fetch_identity_by_b58_id(
     client: &mut DapiClient,
     b58_id: String,
-) -> Result<Vec<u8>, Error> {
+) -> Result<Identity, Error> {
     let identifier = Identifier::from_string(b58_id.as_str(), Encoding::Base58)?;
     let request = platform_proto::GetIdentityRequest {
         id: identifier.to_vec(),
@@ -40,7 +30,7 @@ pub(super) async fn fetch_identity_bytes_by_b58_id(
         ..
     }) = response
     {
-        Ok(bytes)
+        Ok(Identity::deserialize_from_bytes(&bytes)?)
     } else {
         Err(Error::DapiError)
     }

--- a/src/components.rs
+++ b/src/components.rs
@@ -6,7 +6,7 @@ pub(crate) use breadcrumbs::Breadcrumbs;
 pub(crate) use screen::{
     AddWalletScreen, AddWalletScreenCommands, ContractIdInput, ContractScreen,
     ContractScreenCommands, GetContractScreen, GetContractScreenCommands, GetIdentityScreen,
-    GetIdentityScreenCommands, IdentityIdInput, IdentityScreen, IdentityScreenCommands, MainScreen,
-    MainScreenCommands, PrivateKeyInput, WalletScreen, WalletScreenCommands,
+    GetIdentityScreenCommands, IdentityIdInput, IdentityScreen, IdentityScreenCommands, Info,
+    MainScreen, MainScreenCommands, PrivateKeyInput, WalletScreen, WalletScreenCommands,
 };
 pub(crate) use status::Status;

--- a/src/components/screen.rs
+++ b/src/components/screen.rs
@@ -6,6 +6,7 @@ mod get_contract;
 mod get_identity;
 mod identity;
 mod main;
+mod shared;
 mod wallet;
 
 pub(crate) use add_wallet::AddWalletScreen;
@@ -23,5 +24,6 @@ pub(crate) use identity::IdentityScreen;
 pub(crate) use identity::IdentityScreenCommands;
 pub(crate) use main::MainScreen;
 pub(crate) use main::MainScreenCommands;
+pub(crate) use shared::Info;
 pub(crate) use wallet::WalletScreen;
 pub(crate) use wallet::WalletScreenCommands;

--- a/src/components/screen/shared.rs
+++ b/src/components/screen/shared.rs
@@ -1,0 +1,109 @@
+//! Components shared across screens.
+
+use tui_realm_stdlib::Textarea;
+use tuirealm::{
+    command::{Cmd, CmdResult, Direction},
+    event::{Key, KeyEvent, KeyModifiers},
+    props::{Color, PropPayload, TextSpan},
+    tui::prelude::Rect,
+    AttrValue, Attribute, Component, Event, Frame, MockComponent, NoUserEvent, State,
+};
+
+use crate::app::Message;
+
+/// Textarea to represent relevant information for each screen.
+pub(crate) struct Info<const SCROLLABLE: bool, const ERROR_INFO: bool> {
+    component: Textarea,
+}
+
+impl<const SCROLLABLE: bool, const ERROR_INFO: bool> MockComponent
+    for Info<SCROLLABLE, ERROR_INFO>
+{
+    fn view(&mut self, frame: &mut Frame, area: Rect) {
+        self.component.view(frame, area)
+    }
+
+    fn query(&self, attr: Attribute) -> Option<AttrValue> {
+        self.component.query(attr)
+    }
+
+    fn attr(&mut self, _attr: Attribute, _value: AttrValue) {}
+
+    fn state(&self) -> State {
+        self.component.state()
+    }
+
+    fn perform(&mut self, _cmd: Cmd) -> CmdResult {
+        CmdResult::None
+    }
+}
+
+fn str_to_spans(s: &str) -> Vec<TextSpan> {
+    s.lines().map(|line| TextSpan::new(line)).collect()
+}
+
+impl Info<true, true> {
+    pub(crate) fn new_error(text: &str) -> Info<true, true> {
+        let component = Textarea::default()
+            .highlighted_str(">")
+            .foreground(Color::Red)
+            .text_rows(&str_to_spans(text));
+        Info { component }
+    }
+}
+
+impl Info<true, false> {
+    pub(crate) fn new_scrollable(text: &str) -> Info<true, false> {
+        let component = Textarea::default()
+            .highlighted_str(">")
+            .text_rows(&str_to_spans(text));
+        Info { component }
+    }
+}
+
+impl Info<false, false> {
+    pub(crate) fn new_fixed(text: &str) -> Info<false, false> {
+        let component = Textarea::default()
+            .highlighted_str(">")
+            .text_rows(&str_to_spans(text));
+        Info { component }
+    }
+}
+
+/// # Events
+/// In case of scrollable [Info], it reacts on up/down keys or C-p / C-n shortcuts
+impl<const ERROR_INFO: bool> Component<Message, NoUserEvent> for Info<true, ERROR_INFO> {
+    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Message> {
+        match ev {
+            Event::Keyboard(
+                KeyEvent { code: Key::Up, .. }
+                | KeyEvent {
+                    code: Key::Char('p'),
+                    modifiers: KeyModifiers::CONTROL,
+                },
+            ) => {
+                self.component.perform(Cmd::Scroll(Direction::Up));
+                Some(Message::Redraw)
+            }
+            Event::Keyboard(
+                KeyEvent {
+                    code: Key::Down, ..
+                }
+                | KeyEvent {
+                    code: Key::Char('n'),
+                    modifiers: KeyModifiers::CONTROL,
+                },
+            ) => {
+                self.component.perform(Cmd::Scroll(Direction::Down));
+                Some(Message::Redraw)
+            }
+            _ => None,
+        }
+    }
+}
+
+impl<const ERROR_INFO: bool> Component<Message, NoUserEvent> for Info<false, ERROR_INFO> {
+    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Message> {
+        None
+    }
+}


### PR DESCRIPTION
This PR adds a generic Info screen and an application method to show serializable information or a colored error on a screen

so basically if we have `Result<T: Serialize, E: Display>` we can quickly draw it, draw error with red color and use scroll keys in both cases