### PR TITLE
feat: remove selected known_contracts from app state

### DIFF
--- a/src/backend/contracts.rs
+++ b/src/backend/contracts.rs
@@ -75,7 +75,7 @@ pub(super) async fn run_contract_task<'s>(
         }
         ContractTask::RemoveContract(ref contract_name) => {
             let mut contracts_lock = known_contracts.lock().await;
-            contracts_lock.remove(&contract_name.clone());
+            contracts_lock.remove(contract_name);
             BackendEvent::TaskCompletedStateChange {
                 task: Task::Contract(task),
                 execution_result: Ok("Contract removed".into()),

--- a/src/backend/contracts.rs
+++ b/src/backend/contracts.rs
@@ -12,7 +12,7 @@ use super::{as_toml, state::KnownContractsMap, AppStateUpdate, BackendEvent, Tas
 pub(crate) enum ContractTask {
     FetchDashpayContract,
     FetchDPNSContract,
-    ClearKnownContracts,
+    RemoveContract(String),
 }
 
 const DASHPAY_CONTRACT_NAME: &str = "dashpay";
@@ -73,12 +73,12 @@ pub(super) async fn run_contract_task<'s>(
                 },
             }
         }
-        ContractTask::ClearKnownContracts => {
+        ContractTask::RemoveContract(ref contract_name) => {
             let mut contracts_lock = known_contracts.lock().await;
-            contracts_lock.clear();
+            contracts_lock.remove(&contract_name.clone());
             BackendEvent::TaskCompletedStateChange {
                 task: Task::Contract(task),
-                execution_result: Ok("Known contracts cleared".into()),
+                execution_result: Ok("Contract removed".into()),
                 app_state_update: AppStateUpdate::KnownContracts(contracts_lock),
             }
         }

--- a/src/ui/form/widgets/select.rs
+++ b/src/ui/form/widgets/select.rs
@@ -81,11 +81,11 @@ impl<V: Display + Clone> Input for SelectInput<V> {
             } => InputStatus::Done(
                 self.variants[self.input.state().unwrap_one().unwrap_usize()].clone(),
             ),
-            // // Cancel
-            // KeyEvent {
-            //     code: Key::Char('q'),
-            //     modifiers: KeyModifiers::NONE,
-            // } => InputStatus::Exit,
+            // Cancel
+            KeyEvent {
+                code: Key::Char('q'),
+                modifiers: KeyModifiers::NONE,
+            } => InputStatus::Exit,
             _ => InputStatus::None,
         }
     }

--- a/src/ui/views/contracts.rs
+++ b/src/ui/views/contracts.rs
@@ -138,7 +138,14 @@ impl ScreenController for ContractsScreenController {
             Event::Key(KeyEvent {
                 code: Key::Char('r'),
                 modifiers: KeyModifiers::NONE,
-            }) => ScreenFeedback::Form(Box::new(RemoveContractFormController::new(self.known_contracts.clone()))),
+            }) => {
+                let contract_names = self.known_contracts
+                    .iter()
+                    .map(|(name, _)| name.clone())
+                    .collect::<Vec<String>>();
+
+                ScreenFeedback::Form(Box::new(RemoveContractFormController::new(contract_names)))
+            },
 
             Event::Key(event) => {
                 if let Some(select) = &mut self.select {
@@ -165,15 +172,17 @@ impl ScreenController for ContractsScreenController {
                     ..
                 },
             ) => {
-                self.select = if known_contracts.len() > 0 {
+                self.select = if !known_contracts.is_empty() {
                     Some(SelectInput::new(Self::contract_entries_vec(
                         known_contracts.iter().map(|(k, v)| (k.clone(), v)),
                     )))
                 } else {
                     None
                 };
+                self.known_contracts = (*known_contracts).clone();
                 ScreenFeedback::Redraw
             }
+                        
             _ => ScreenFeedback::None,
         }
     }
@@ -184,10 +193,9 @@ pub(super) struct RemoveContractFormController {
 }
 
 impl RemoveContractFormController {
-    pub(super) fn new(contracts: BTreeMap<String, DataContract>) -> Self {
-        let contract_names = contracts.keys().cloned().collect_vec();
+    pub(super) fn new(contracts: Vec<String>) -> Self {
         Self {
-            input: SelectInput::new(contract_names),
+            input: SelectInput::new(contracts),
         }
     }
 }


### PR DESCRIPTION
Added a button with selection form that allows users to select a known_contract to remove from the app state. 

Also re-enabled the ability to exit out of a selection form by pressing `q`.