### PR TITLE
feat: verify proofs for state transitions in strategies

### DIFF
--- a/.env.testnet
+++ b/.env.testnet
@@ -8,7 +8,7 @@ EXPLORER_CORE_HOST=127.0.0.1
 EXPLORER_CORE_RPC_PORT=9998
 
 # The username for authentication with Dash Core RPC
-EXPLORER_CORE_RPC_USER=paul
+EXPLORER_CORE_RPC_USER=user
 
 # The password for authentication with Dash Core RPC
 EXPLORER_CORE_RPC_PASSWORD=password

--- a/.env.testnet
+++ b/.env.testnet
@@ -5,7 +5,7 @@ EXPLORER_DAPI_ADDRESSES=https://34.214.48.68:1443,https://35.165.50.126:1443,htt
 EXPLORER_CORE_HOST=127.0.0.1
 
 # The port number on which Dash Core RPC is listening.
-EXPLORER_CORE_RPC_PORT=9998
+EXPLORER_CORE_RPC_PORT=19998
 
 # The username for authentication with Dash Core RPC
 EXPLORER_CORE_RPC_USER=user

--- a/.env.testnet
+++ b/.env.testnet
@@ -5,10 +5,10 @@ EXPLORER_DAPI_ADDRESSES=https://34.214.48.68:1443,https://35.165.50.126:1443,htt
 EXPLORER_CORE_HOST=127.0.0.1
 
 # The port number on which Dash Core RPC is listening.
-EXPLORER_CORE_RPC_PORT=19998
+EXPLORER_CORE_RPC_PORT=9998
 
 # The username for authentication with Dash Core RPC
-EXPLORER_CORE_RPC_USER=user
+EXPLORER_CORE_RPC_USER=paul
 
 # The password for authentication with Dash Core RPC
 EXPLORER_CORE_RPC_PASSWORD=password

--- a/src/backend/strategies.rs
+++ b/src/backend/strategies.rs
@@ -440,7 +440,10 @@ pub(crate) async fn run_strategy_task<'s>(
             };
 
             let mut loaded_identity_lock = match app_state.refresh_identity(&sdk).await {
-                Ok(lock) => lock,
+                Ok(lock) => {
+                    info!("Refreshed loaded identity.");
+                    lock
+                },                
                 Err(e) => {
                     error!("Failed to refresh identity: {:?}", e);
                     return BackendEvent::StrategyError {

--- a/src/backend/strategies.rs
+++ b/src/backend/strategies.rs
@@ -870,15 +870,13 @@ pub(crate) async fn run_strategy_task<'s>(
                                                         }
                                                     }
                                                     Err(e) => error!(
-                                                        "Error waiting for state transition \
-                                                         result: {:?}",
+                                                        "Error waiting for state transition result: {:?}",
                                                         e
                                                     ),
                                                 }
                                             } else {
                                                 error!(
-                                                    "Failed to create wait request for state \
-                                                     transition."
+                                                    "Failed to create wait request for state transition."
                                                 );
                                             }
                                         }
@@ -1095,6 +1093,19 @@ pub(crate) async fn run_strategy_task<'s>(
                 let dash_spent_wallet = (initial_balance_wallet as f64
                     - final_balance_wallet as f64)
                     / 100_000_000_000.0;
+
+                info!(
+                    "-----Strategy '{}' completed-----\n\nState transitions attempted: {}\nState \
+                    transitions succeeded: {}\nNumber of blocks: {}\nRun time: \
+                    {:?}\nDash spent (Identity): {}\nDash spent (Wallet): {}",
+                    strategy_name,
+                    transition_count,
+                    success_count,
+                    (current_block_info.height - initial_block_info.height),
+                    run_time,
+                    dash_spent_identity,
+                    dash_spent_wallet,
+                );
 
                 BackendEvent::StrategyCompleted {
                     strategy_name: strategy_name.clone(),

--- a/src/backend/strategies.rs
+++ b/src/backend/strategies.rs
@@ -17,8 +17,7 @@ use dpp::{
     block::{block_info::BlockInfo, epoch::Epoch},
     dashcore::PrivateKey,
     data_contract::{
-        created_data_contract::CreatedDataContract,
-        DataContract,
+        created_data_contract::CreatedDataContract, DataContract
     },
     identity::{
         accessors::IdentityGettersV0, state_transition::asset_lock_proof::AssetLockProof, Identity,
@@ -988,8 +987,9 @@ pub(crate) async fn run_strategy_task<'s>(
                                                             index + 1, transition.name(), current_block_info.height, actual_block_height
                                                         );
                                     
-                                                        // Verification of the proof, similar to the dependent transitions
+                                                        // Verification of the proof
                                                         if let Some(wait_for_state_transition_result_response_v0::Result::Proof(proof)) = &v0_response.result {
+                                                            // For proof verification, if it's a DocumentsBatch, include the data contract, else don't
                                                             let verified = if transition.name() == "DocumentsBatch" {
                                                                 match data_contract_clone.as_ref() {
                                                                     Some(data_contract) => {
@@ -1010,14 +1010,10 @@ pub(crate) async fn run_strategy_task<'s>(
                                                                     sdk.version(),
                                                                 )
                                                             };
-                                    
+
                                                             match verified {
-                                                                Ok(_) => {
-                                                                    info!("Verified proof for state transition");
-                                                                },
-                                                                Err(e) => {
-                                                                    error!("Error verifying state transition execution proof: {}", e);
-                                                                }
+                                                                Ok(_) => info!("Verified proof for state transition {}", index+1),
+                                                                Err(e) => error!("Error verifying state transition execution proof: {}", e),
                                                             }
                                                         }
                                                     }

--- a/src/backend/wallet.rs
+++ b/src/backend/wallet.rs
@@ -42,7 +42,7 @@ pub(super) async fn run_wallet_task<'s>(
             let private_key = if private_key.len() == 64 {
                 // hex
                 let bytes = hex::decode(private_key).expect("expected hex"); // TODO error hadling
-                PrivateKey::from_slice(bytes.as_slice(), Network::Devnet)
+                PrivateKey::from_slice(bytes.as_slice(), Network::Testnet)
                     .expect("expected private key")
             } else {
                 PrivateKey::from_wif(private_key.as_str()).expect("expected WIF key")
@@ -52,7 +52,7 @@ pub(super) async fn run_wallet_task<'s>(
             let secp = Secp256k1::new();
             let public_key = private_key.public_key(&secp);
             // todo: make the network be part of state
-            let address = Address::p2pkh(&public_key, Network::Devnet);
+            let address = Address::p2pkh(&public_key, Network::Testnet);
             let wallet = Wallet::SingleKeyWallet(SingleKeyWallet {
                 private_key,
                 public_key,
@@ -144,7 +144,7 @@ impl Wallet {
         };
         let fee = 2000;
         let random_private_key: [u8; 32] = rng.gen();
-        let private_key = PrivateKey::from_slice(&random_private_key, Network::Devnet)
+        let private_key = PrivateKey::from_slice(&random_private_key, Network::Testnet)
             .expect("expected a private key");
 
         let secp = Secp256k1::new();
@@ -365,13 +365,13 @@ impl Decode for SingleKeyWallet {
         let bytes = <[u8; 32]>::decode(decoder)?;
         let string_utxos = Vec::<(String, u64, String)>::decode(decoder)?;
 
-        let private_key = PrivateKey::from_slice(bytes.as_slice(), Network::Devnet)
+        let private_key = PrivateKey::from_slice(bytes.as_slice(), Network::Testnet)
             .expect("expected private key");
 
         let secp = Secp256k1::new();
         let public_key = private_key.public_key(&secp);
         // todo: make the network be part of state
-        let address = Address::p2pkh(&public_key, Network::Devnet);
+        let address = Address::p2pkh(&public_key, Network::Testnet);
 
         let utxos = string_utxos
             .iter()
@@ -408,13 +408,13 @@ impl<'a> BorrowDecode<'a> for SingleKeyWallet {
         let bytes = <[u8; 32]>::decode(decoder)?;
         let string_utxos = Vec::<(String, u64, String)>::decode(decoder)?;
 
-        let private_key = PrivateKey::from_slice(bytes.as_slice(), Network::Devnet)
+        let private_key = PrivateKey::from_slice(bytes.as_slice(), Network::Testnet)
             .expect("expected private key");
 
         let secp = Secp256k1::new();
         let public_key = private_key.public_key(&secp);
         // todo: make the network be part of state
-        let address = Address::p2pkh(&public_key, Network::Devnet);
+        let address = Address::p2pkh(&public_key, Network::Testnet);
 
         let utxos = string_utxos
             .iter()

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,7 +47,7 @@ impl Config {
     /// and prefixed with [LOCAL_EXPLORER_](Config::CONFIG_PREFIX).
     pub fn load() -> Self {
         // load config from .env file
-        if let Err(err) = dotenvy::from_path(".env.testnet") {
+        if let Err(err) = dotenvy::from_path(".env") {
             tracing::warn!(?err, "failed to load config file");
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,7 +47,7 @@ impl Config {
     /// and prefixed with [LOCAL_EXPLORER_](Config::CONFIG_PREFIX).
     pub fn load() -> Self {
         // load config from .env file
-        if let Err(err) = dotenvy::from_path(".env.local") {
+        if let Err(err) = dotenvy::from_path(".env.testnet") {
             tracing::warn!(?err, "failed to load config file");
         }
 

--- a/src/ui/views/strategies/run_strategy_screen.rs
+++ b/src/ui/views/strategies/run_strategy_screen.rs
@@ -99,7 +99,7 @@ impl ScreenController for RunStrategyScreenController {
                         dash_spent_wallet,
                     } => {
                         format!(
-                            "Strategy '{}' completed:\nState transitions attempted: {}\nState \
+                            "Strategy '{}' completed:\n\nState transitions attempted: {}\nState \
                              transitions succeeded: {}\nNumber of blocks: {}\nRun time: \
                              {:?}\nDash spent (Identity): {}\nDash spent (Wallet): {}",
                             strategy_name,


### PR DESCRIPTION
Added proof verification that state transitions were included in the block and updated the chain state. After every ST, we log whether the proof was verified or not, and the error if not.

Since the state_transitions_for_block function returns a vector of StateTransition, we verify proofs with verify_state_transition_was_executed_with_proof, which is implemented for StateTransition, rather than using functions like put_to_platform_and_wait_for_response, which are implemented for Document, Identity, etc.