### PR TITLE
fix: identity add keys STs duplicating KeyIDs in same block

### DIFF
--- a/src/backend/strategies.rs
+++ b/src/backend/strategies.rs
@@ -732,7 +732,8 @@ pub(crate) async fn run_strategy_task<'s>(
                     let mut known_contracts_lock = app_state.known_contracts.lock().await;
 
                     // Call the function to get STs for block
-                    let (transitions, finalize_operations) = strategy
+                    // finalize_operations are actually handled within this function now.
+                    let (transitions, _finalize_operations) = strategy
                         .state_transitions_for_block_with_new_identities(
                             &mut document_query_callback,
                             &mut identity_fetch_callback,
@@ -756,23 +757,6 @@ pub(crate) async fn run_strategy_task<'s>(
 
                     // TO-DO: add documents from state transitions to explorer.drive here
                     // this is required for DocumentDelete and DocumentReplace strategy operations
-
-                    // Process each FinalizeBlockOperation, which so far is just adding keys to the
-                    // identities
-                    for operation in finalize_operations {
-                        match operation {
-                            FinalizeBlockOperation::IdentityAddKeys(identifier, keys) => {
-                                if let Some(identity) = current_identities
-                                    .iter_mut()
-                                    .find(|id| id.id() == identifier)
-                                {
-                                    for key in keys {
-                                        identity.add_public_key(key);
-                                    }
-                                }
-                            }
-                        }
-                    }
 
                     // Update the loaded_identity_clone and loaded_identity_lock with the latest
                     // state of the identity


### PR DESCRIPTION
If you did multiple IdentityAddKeys state transition in the same block, the Identity public keys would not update between state transition creation, so we were creating duplicate KeyIDs. To solve this, I am adding the keys to the identity within the state_transitions_for_block function in between each state transition, rather than waiting until until all the state transitions for the block are created. This essentially moves the handling of finalize_block_operations, which is returned by state_transitions_for_block, into state_transitions_for_block, so there really is no need to return it anymore.