### PR TITLE
feat: enable credit withdrawals in strategies

### DIFF
--- a/src/ui/views/strategies/operations.rs
+++ b/src/ui/views/strategies/operations.rs
@@ -31,7 +31,7 @@ enum OperationType {
     IdentityTopUp,
     IdentityAddKeys,
     IdentityDisableKeys,
-    // IdentityWithdrawal,
+    IdentityWithdrawal,
     IdentityTransfer,
     // ContractCreateRandom,
     ContractUpdateDocTypesRandom,
@@ -79,9 +79,9 @@ impl StrategyAddOperationFormController {
                     identity_update::KeyUpdateOp::DisableKeys,
                 ))
             }
-            // OperationType::IdentityWithdrawal => Box::new(
-            //     StrategyOpIdentityWithdrawalFormController::new(self.strategy_name.clone()),
-            // ),
+            OperationType::IdentityWithdrawal => Box::new(
+                StrategyOpIdentityWithdrawalFormController::new(self.strategy_name.clone()),
+            ),
             OperationType::IdentityTransfer => Box::new(
                 StrategyOpIdentityTransferFormController::new(self.strategy_name.clone()),
             ),


### PR DESCRIPTION
I just uncommented the section of the code that handled credit withdrawals. Running withdrawals via these strategy tests broke testnet on the very first withdrawal of the strategy, but they run completely fine on a local network using v1.0-dev, even doing multiple withdrawals per block for many blocks.