### PR TITLE
fix: replace entropy with identity nonce for contracts

### DIFF
--- a/src/backend/state.rs
+++ b/src/backend/state.rs
@@ -2,7 +2,7 @@
 //! This kind of state does not include UI details and basically all about
 //! persistence required by backend.
 
-use std::{collections::BTreeMap, fs, sync::Arc};
+use std::{collections::BTreeMap, fs};
 
 use bincode::{Decode, Encode};
 use dpp::{
@@ -16,11 +16,10 @@ use dpp::{
         PlatformDeserializableWithPotentialValidationFromVersionedStructure,
         PlatformSerializableWithPlatformVersion,
     },
-    tests::json_document::json_document_to_created_contract,
+    tests::json_document::json_document_to_contract,
     util::deserializer::ProtocolVersion,
     version::PlatformVersion,
-    ProtocolError,
-    ProtocolError::{PlatformDeserializationError, PlatformSerializationError},
+    ProtocolError::{self, PlatformDeserializationError, PlatformSerializationError},
 };
 use drive::drive::Drive;
 use strategy_tests::Strategy;
@@ -96,9 +95,9 @@ impl Default for AppState {
             let path = entry.path();
             let contract_name = path.file_stem().unwrap().to_str().unwrap().to_string();
 
-            if let Ok(contract) = json_document_to_created_contract(&path, true, platform_version) {
+            if let Ok(contract) = json_document_to_contract(&path, true, platform_version) {
                 // Insert the contract into supporting_contracts_raw
-                supporting_contracts_raw.insert(contract_name, contract.data_contract_owned());
+                supporting_contracts_raw.insert(contract_name, contract);
             }
         }
 
@@ -427,8 +426,8 @@ impl AppState {
             let path = entry.path();
             let contract_name = path.file_stem().unwrap().to_str().unwrap().to_string();
 
-            if let Ok(contract) = json_document_to_created_contract(&path, true, platform_version) {
-                supporting_contracts.insert(contract_name, contract.data_contract_owned());
+            if let Ok(contract) = json_document_to_contract(&path, true, platform_version) {
+                supporting_contracts.insert(contract_name, contract);
             }
         }
 

--- a/src/backend/strategies.rs
+++ b/src/backend/strategies.rs
@@ -232,7 +232,7 @@ pub(crate) async fn run_strategy_task<'s>(
                     }
                 };    
                 let identity_nonce = sdk
-                    .get_identity_nonce(loaded_identity_lock.id(), false, None)
+                    .get_identity_nonce(loaded_identity_lock.id(), true, None)
                     .await
                     .expect("Couldn't get current identity nonce");
 

--- a/src/backend/strategies.rs
+++ b/src/backend/strategies.rs
@@ -24,7 +24,7 @@ use dpp::{
         accessors::IdentityGettersV0, state_transition::asset_lock_proof::AssetLockProof, Identity,
         PartialIdentity,
     },
-    platform_value::{string_encoding::Encoding, Bytes32, Identifier},
+    platform_value::{string_encoding::Encoding, Identifier},
     state_transition::{
         data_contract_create_transition::DataContractCreateTransition, StateTransition,
     },
@@ -209,7 +209,6 @@ pub(crate) async fn run_strategy_task<'s>(
                 app_state.available_strategies_contract_names.lock().await;
 
             if let Some(strategy) = strategies_lock.get_mut(&strategy_name) {
-                let mut rng = StdRng::from_entropy();
                 let platform_version = PlatformVersion::latest();
 
                 // Function to retrieve the contract from either known_contracts or
@@ -221,12 +220,27 @@ pub(crate) async fn run_strategy_task<'s>(
                         .cloned()
                 };
 
+                // Get the loaded identity nonce
+                let loaded_identity_lock = match app_state.refresh_identity(&sdk).await {
+                    Ok(lock) => lock,
+                    Err(e) => {
+                        error!("Failed to refresh identity: {:?}", e);
+                        return BackendEvent::StrategyError {
+                            strategy_name: strategy_name.clone(),
+                            error: format!("Failed to refresh identity: {:?}", e),
+                        };
+                    }
+                };    
+                let identity_nonce = sdk
+                    .get_identity_nonce(loaded_identity_lock.id(), false, None)
+                    .await
+                    .expect("Couldn't get current identity nonce");
+
                 if let Some(first_contract_name) = selected_contract_names.first() {
                     if let Some(data_contract) = get_contract(first_contract_name) {
-                        let entropy = Bytes32::random_with_rng(&mut rng);
-                        match CreatedDataContract::from_contract_and_entropy(
+                        match CreatedDataContract::from_contract_and_identity_nonce(
                             data_contract,
-                            entropy,
+                            identity_nonce,
                             platform_version,
                         ) {
                             Ok(initial_contract) => {
@@ -236,10 +250,9 @@ pub(crate) async fn run_strategy_task<'s>(
                                     selected_contract_names.iter().enumerate().skip(1)
                                 {
                                     if let Some(update_contract) = get_contract(contract_name) {
-                                        let update_entropy = Bytes32::random_with_rng(&mut rng);
-                                        match CreatedDataContract::from_contract_and_entropy(
+                                        match CreatedDataContract::from_contract_and_identity_nonce(
                                             update_contract,
-                                            update_entropy,
+                                            identity_nonce,
                                             platform_version,
                                         ) {
                                             Ok(created_update_contract) => {

--- a/src/bin/load_test.rs
+++ b/src/bin/load_test.rs
@@ -300,7 +300,7 @@ async fn broadcast_contract_variants(
     count: u32,
     _seed: u64,
 ) -> Vec<DataContract> {
-    let identity_nonce = sdk.get_identity_nonce(identity.id(), false, None)
+    let identity_nonce = sdk.get_identity_nonce(identity.id(), true, None)
         .await
         .expect("Couldn't get identity nonce");
 

--- a/src/ui/views/strategies/contracts_with_updates_screen.rs
+++ b/src/ui/views/strategies/contracts_with_updates_screen.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use dpp::{
     data_contract::{created_data_contract::CreatedDataContract, DataContract},
-    tests::json_document::json_document_to_created_contract,
+    tests::json_document::json_document_to_contract,
     version::PlatformVersion,
 };
 use strategy_tests::Strategy;
@@ -98,13 +98,12 @@ impl ContractsWithUpdatesScreenController {
             let path = entry.path();
             let contract_name = path.file_stem().unwrap().to_str().unwrap().to_string();
 
-            // Change here: Add to supporting_contracts instead of known_contracts
             if !self.supporting_contracts.contains_key(&contract_name) {
                 if let Ok(contract) =
-                    json_document_to_created_contract(&path, true, platform_version)
+                    json_document_to_contract(&path, true, platform_version)
                 {
                     self.supporting_contracts
-                        .insert(contract_name, contract.data_contract_owned());
+                        .insert(contract_name, contract);
                 }
             }
         }

--- a/src/ui/views/strategies/operations_screen.rs
+++ b/src/ui/views/strategies/operations_screen.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use dpp::{
     data_contract::{created_data_contract::CreatedDataContract, DataContract},
-    tests::json_document::json_document_to_created_contract,
+    tests::json_document::json_document_to_contract,
     version::PlatformVersion,
 };
 use strategy_tests::{
@@ -104,13 +104,12 @@ impl OperationsScreenController {
             let path = entry.path();
             let contract_name = path.file_stem().unwrap().to_str().unwrap().to_string();
 
-            // Change here: Add to supporting_contracts instead of known_contracts
             if !self.supporting_contracts.contains_key(&contract_name) {
                 if let Ok(contract) =
-                    json_document_to_created_contract(&path, true, platform_version)
+                    json_document_to_contract(&path, true, platform_version)
                 {
                     self.supporting_contracts
-                        .insert(contract_name, contract.data_contract_owned());
+                        .insert(contract_name, contract);
                 }
             }
         }


### PR DESCRIPTION
There were multiple parts of the codebase that needed to be updated now that contract creation requires identity nonce instead of entropy