### PR TITLE
fix: force sdk to get nonces from platform between strategies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
+name = "arc-swap"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b3d0060af21e8d11a926981cc00c6c1541aa91dd64b9f881985c3da1094425f"
+
+[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,7 +470,7 @@ dependencies = [
 [[package]]
 name = "bls-dash-sys"
 version = "1.2.5"
-source = "git+https://github.com/dashpay/bls-signatures?branch=develop#1c2fc79c19dc8041610c005e68d58bfb4bc32721"
+source = "git+https://github.com/dashpay/bls-signatures?tag=v1.3.1#1c2fc79c19dc8041610c005e68d58bfb4bc32721"
 dependencies = [
  "bindgen",
  "cc",
@@ -474,7 +480,7 @@ dependencies = [
 [[package]]
 name = "bls-signatures"
 version = "1.2.5"
-source = "git+https://github.com/dashpay/bls-signatures?branch=develop#1c2fc79c19dc8041610c005e68d58bfb4bc32721"
+source = "git+https://github.com/dashpay/bls-signatures?tag=v1.3.1#1c2fc79c19dc8041610c005e68d58bfb4bc32721"
 dependencies = [
  "bls-dash-sys",
  "hex",
@@ -955,22 +961,23 @@ dependencies = [
 
 [[package]]
 name = "dapi-grpc"
-version = "1.0.0-dev.5"
+version = "1.0.0-dev.7"
 dependencies = [
  "dapi-grpc-macros",
+ "futures-core",
  "platform-version",
- "prost 0.11.9",
+ "prost 0.12.3",
  "serde",
  "serde_bytes",
  "serde_json",
- "tenderdash-proto 0.14.0-dev.6 (git+https://github.com/dashpay/rs-tenderdash-abci)",
+ "tenderdash-proto",
  "tonic",
- "tonic-build",
+ "tonic-build 0.9.2",
 ]
 
 [[package]]
 name = "dapi-grpc-macros"
-version = "1.0.0-dev.5"
+version = "1.0.0-dev.7"
 dependencies = [
  "heck",
  "quote",
@@ -1088,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "dashpay-contract"
-version = "1.0.0-dev.5"
+version = "1.0.0-dev.7"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -1098,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "data-contracts"
-version = "1.0.0-dev.5"
+version = "1.0.0-dev.7"
 dependencies = [
  "dashpay-contract",
  "dpns-contract",
@@ -1179,7 +1186,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dpns-contract"
-version = "1.0.0-dev.5"
+version = "1.0.0-dev.7"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -1189,7 +1196,7 @@ dependencies = [
 
 [[package]]
 name = "dpp"
-version = "1.0.0-dev.5"
+version = "1.0.0-dev.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1232,13 +1239,13 @@ dependencies = [
  "sha2",
  "strum 0.25.0",
  "thiserror",
- "tracing",
 ]
 
 [[package]]
 name = "drive"
-version = "1.0.0-dev.5"
+version = "1.0.0-dev.7"
 dependencies = [
+ "arc-swap",
  "base64 0.21.7",
  "bs58 0.5.0",
  "byteorder",
@@ -1258,6 +1265,7 @@ dependencies = [
  "itertools 0.11.0",
  "moka",
  "nohash-hasher",
+ "parking_lot",
  "platform-version",
  "rand",
  "serde",
@@ -1270,7 +1278,7 @@ dependencies = [
 
 [[package]]
 name = "drive-proof-verifier"
-version = "1.0.0-dev.5"
+version = "1.0.0-dev.7"
 dependencies = [
  "dapi-grpc",
  "dpp",
@@ -1489,7 +1497,7 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "feature-flags-contract"
-version = "1.0.0-dev.5"
+version = "1.0.0-dev.7"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2417,7 +2425,7 @@ dependencies = [
 
 [[package]]
 name = "masternode-reward-shares-contract"
-version = "1.0.0-dev.5"
+version = "1.0.0-dev.7"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2957,7 +2965,7 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "platform-serialization"
-version = "1.0.0-dev.5"
+version = "1.0.0-dev.7"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "platform-version",
@@ -2965,7 +2973,7 @@ dependencies = [
 
 [[package]]
 name = "platform-serialization-derive"
-version = "1.0.0-dev.5"
+version = "1.0.0-dev.7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2975,7 +2983,7 @@ dependencies = [
 
 [[package]]
 name = "platform-value"
-version = "1.0.0-dev.5"
+version = "1.0.0-dev.7"
 dependencies = [
  "base64 0.13.1",
  "bincode 2.0.0-rc.3",
@@ -2996,14 +3004,14 @@ dependencies = [
 
 [[package]]
 name = "platform-version"
-version = "1.0.0-dev.5"
+version = "1.0.0-dev.7"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "platform-versioning"
-version = "1.0.0-dev.5"
+version = "1.0.0-dev.7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3457,7 +3465,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3529,7 +3537,7 @@ dependencies = [
 
 [[package]]
 name = "rs-dapi-client"
-version = "1.0.0-dev.5"
+version = "1.0.0-dev.7"
 dependencies = [
  "backon",
  "chrono",
@@ -3587,7 +3595,7 @@ dependencies = [
 
 [[package]]
 name = "rs-sdk"
-version = "1.0.0-dev.5"
+version = "1.0.0-dev.7"
 dependencies = [
  "async-trait",
  "bincode 2.0.0-rc.3",
@@ -3702,18 +3710,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
@@ -3721,19 +3717,20 @@ dependencies = [
  "log",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.2",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.6.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 2.1.1",
+ "rustls-pki-types",
  "schannel",
  "security-framework",
 ]
@@ -3748,20 +3745,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f48172685e6ff52a556baa527774f61fcaa884f59daf3375c62a3f1cd2549dab"
+dependencies = [
+ "base64 0.21.7",
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "048a63e5b3ac996d78d402940b5fa47973d2d080c6c6fffa1d0f19c4445310b7"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -3818,16 +3815,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "seahash"
@@ -4062,7 +4049,7 @@ checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "simple-signer"
-version = "1.0.0-dev.5"
+version = "1.0.0-dev.7"
 dependencies = [
  "anyhow",
  "bincode 2.0.0-rc.3",
@@ -4168,7 +4155,7 @@ checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
 name = "strategy-tests"
-version = "1.0.0-dev.5"
+version = "1.0.0-dev.7"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "dpp",
@@ -4375,7 +4362,7 @@ dependencies = [
 [[package]]
 name = "tenderdash-abci"
 version = "0.14.0-dev.6"
-source = "git+https://github.com/dashpay/rs-tenderdash-abci?tag=v0.14.0-dev.6#701ba0fa92cb0f6bb5b986ec1ad141390040116c"
+source = "git+https://github.com/dashpay/rs-tenderdash-abci?rev=81d28aa0b15fc0844dfa7f7251f6949f6c6c405a#81d28aa0b15fc0844dfa7f7251f6949f6c6c405a"
 dependencies = [
  "bytes",
  "futures",
@@ -4383,7 +4370,7 @@ dependencies = [
  "lhash",
  "prost 0.12.3",
  "semver",
- "tenderdash-proto 0.14.0-dev.6 (git+https://github.com/dashpay/rs-tenderdash-abci?tag=v0.14.0-dev.6)",
+ "tenderdash-proto",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -4396,7 +4383,7 @@ dependencies = [
 [[package]]
 name = "tenderdash-proto"
 version = "0.14.0-dev.6"
-source = "git+https://github.com/dashpay/rs-tenderdash-abci?tag=v0.14.0-dev.6#701ba0fa92cb0f6bb5b986ec1ad141390040116c"
+source = "git+https://github.com/dashpay/rs-tenderdash-abci?rev=81d28aa0b15fc0844dfa7f7251f6949f6c6c405a#81d28aa0b15fc0844dfa7f7251f6949f6c6c405a"
 dependencies = [
  "bytes",
  "chrono",
@@ -4405,53 +4392,24 @@ dependencies = [
  "num-derive",
  "num-traits",
  "prost 0.12.3",
+ "prost-types 0.12.3",
  "serde",
  "subtle-encoding",
- "tenderdash-proto-compiler 0.14.0-dev.6 (git+https://github.com/dashpay/rs-tenderdash-abci?tag=v0.14.0-dev.6)",
+ "tenderdash-proto-compiler",
  "time",
-]
-
-[[package]]
-name = "tenderdash-proto"
-version = "0.14.0-dev.6"
-source = "git+https://github.com/dashpay/rs-tenderdash-abci#8b5afe6b653a430941d803f3c729c7c6d073734d"
-dependencies = [
- "bytes",
- "chrono",
- "derive_more",
- "flex-error",
- "num-derive",
- "num-traits",
- "prost 0.12.3",
- "serde",
- "subtle-encoding",
- "tenderdash-proto-compiler 0.14.0-dev.6 (git+https://github.com/dashpay/rs-tenderdash-abci)",
- "time",
+ "tonic",
 ]
 
 [[package]]
 name = "tenderdash-proto-compiler"
 version = "0.14.0-dev.6"
-source = "git+https://github.com/dashpay/rs-tenderdash-abci?tag=v0.14.0-dev.6#701ba0fa92cb0f6bb5b986ec1ad141390040116c"
+source = "git+https://github.com/dashpay/rs-tenderdash-abci?rev=81d28aa0b15fc0844dfa7f7251f6949f6c6c405a#81d28aa0b15fc0844dfa7f7251f6949f6c6c405a"
 dependencies = [
  "fs_extra",
  "prost-build 0.12.3",
  "regex",
  "tempfile",
- "ureq",
- "walkdir",
- "zip",
-]
-
-[[package]]
-name = "tenderdash-proto-compiler"
-version = "0.14.0-dev.6"
-source = "git+https://github.com/dashpay/rs-tenderdash-abci#8b5afe6b653a430941d803f3c729c7c6d073734d"
-dependencies = [
- "fs_extra",
- "prost-build 0.12.3",
- "regex",
- "tempfile",
+ "tonic-build 0.11.0",
  "ureq",
  "walkdir",
  "zip",
@@ -4605,11 +4563,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
- "rustls 0.21.10",
+ "rustls",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -4696,17 +4655,15 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
+checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
 dependencies = [
  "async-stream",
  "async-trait",
  "axum",
  "base64 0.21.7",
  "bytes",
- "futures-core",
- "futures-util",
  "h2",
  "http",
  "http-body",
@@ -4714,9 +4671,10 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.11.9",
+ "prost 0.12.3",
  "rustls-native-certs",
- "rustls-pemfile",
+ "rustls-pemfile 2.1.1",
+ "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -4737,6 +4695,19 @@ dependencies = [
  "prost-build 0.11.9",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4ef6dd70a610078cb4e338a0f79d06bc759ff1b22d2120c2ff02ae264ba9c2"
+dependencies = [
+ "prettyplease 0.2.16",
+ "proc-macro2",
+ "prost-build 0.12.3",
+ "quote",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -5011,9 +4982,9 @@ dependencies = [
  "flate2",
  "log",
  "once_cell",
- "rustls 0.22.2",
+ "rustls",
  "rustls-pki-types",
- "rustls-webpki 0.102.2",
+ "rustls-webpki",
  "url",
  "webpki-roots",
 ]
@@ -5479,7 +5450,7 @@ dependencies = [
 
 [[package]]
 name = "withdrawals-contract"
-version = "1.0.0-dev.5"
+version = "1.0.0-dev.7"
 dependencies = [
  "num_enum",
  "platform-value",

--- a/src/backend/strategies.rs
+++ b/src/backend/strategies.rs
@@ -561,7 +561,13 @@ pub(crate) async fn run_strategy_task<'s>(
 
                 let mut identity_nonce_counter = BTreeMap::new();
                 let current_identity_nonce = sdk
-                    .get_identity_nonce(loaded_identity_clone.id(), false, None)
+                    .get_identity_nonce(
+                        loaded_identity_clone.id(),
+                        false,
+                        Some(rs_sdk::platform::transition::put_settings::PutSettings {
+                            request_settings: RequestSettings::default(),
+                            identity_nonce_stale_time_s: Some(1),
+                        }))
                     .await
                     .expect("Couldn't get current identity nonce");
                 identity_nonce_counter.insert(loaded_identity_clone.id(), current_identity_nonce);
@@ -572,7 +578,10 @@ pub(crate) async fn run_strategy_task<'s>(
                             loaded_identity_clone.id(),
                             used_contract_id,
                             false,
-                            None,
+                            Some(rs_sdk::platform::transition::put_settings::PutSettings {
+                                request_settings: RequestSettings::default(),
+                                identity_nonce_stale_time_s: Some(1),
+                            })
                         )
                         .await
                         .expect("Couldn't get current identity contract nonce");

--- a/src/backend/strategies.rs
+++ b/src/backend/strategies.rs
@@ -75,8 +75,8 @@ pub(crate) enum StrategyTask {
     },
     SetStartIdentities {
         strategy_name: String,
-        count: u16,
-        key_count: u32,
+        count: u8,
+        keys_count: u8,
     },
     AddOperation {
         strategy_name: String,
@@ -362,74 +362,23 @@ pub(crate) async fn run_strategy_task<'s>(
             }
         }
         StrategyTask::SetStartIdentities {
-            ref strategy_name,
+            strategy_name,
             count,
-            key_count,
+            keys_count,
         } => {
             let mut strategies_lock = app_state.available_strategies.lock().await;
-            let loaded_identity_lock = app_state.loaded_identity.lock().await;
-            let identity_private_keys_lock = app_state.identity_private_keys.lock().await;
-
-            if let Some(strategy) = strategies_lock.get_mut(strategy_name) {
-                // Ensure a signer is present, creating a new one if necessary
-                let signer = if let Some(signer) = strategy.signer.as_mut() {
-                    // Use the existing signer
-                    signer
-                } else {
-                    // Create a new signer from loaded_identity if one doesn't exist, else default
-                    let new_signer = if let Some(loaded_identity) = &*loaded_identity_lock {
-                        let mut signer = SimpleSigner::default();
-                        match loaded_identity {
-                            Identity::V0(identity_v0) => {
-                                for (key_id, public_key) in &identity_v0.public_keys {
-                                    let identity_key_tuple = (identity_v0.id, *key_id);
-                                    if let Some(private_key_bytes) =
-                                        identity_private_keys_lock.get(&identity_key_tuple)
-                                    {
-                                        signer
-                                            .private_keys
-                                            .insert(public_key.clone(), private_key_bytes.clone());
-                                    }
-                                }
-                            }
-                        }
-                        signer
-                    } else {
-                        SimpleSigner::default()
-                    };
-                    strategy.signer = Some(new_signer);
-                    strategy.signer.as_mut().unwrap()
-                };
-
-                match set_start_identities(count, key_count, signer, app_state, &sdk, insight).await
-                {
-                    Ok(identities_and_transitions) => {
-                        strategy.start_identities = identities_and_transitions;
-                        BackendEvent::TaskCompletedStateChange {
-                            task: Task::Strategy(task.clone()),
-                            execution_result: Ok("Start identities set".into()),
-                            app_state_update: AppStateUpdate::SelectedStrategy(
-                                strategy_name.to_string(),
-                                MutexGuard::map(strategies_lock, |strategies| {
-                                    strategies.get_mut(strategy_name).expect("strategy exists")
-                                }),
-                                MutexGuard::map(
-                                    app_state.available_strategies_contract_names.lock().await,
-                                    |names| {
-                                        names.get_mut(strategy_name).expect("inconsistent data")
-                                    },
-                                ),
-                            ),
-                        }
-                    }
-                    Err(e) => {
-                        error!("Error setting start identities: {:?}", e);
-                        BackendEvent::StrategyError {
-                            strategy_name: strategy_name.clone(),
-                            error: format!("Error setting start identities: {}", e),
-                        }
-                    }
-                }
+            if let Some(strategy) = strategies_lock.get_mut(&strategy_name) {
+                strategy.start_identities = (count, keys_count);
+                BackendEvent::AppStateUpdated(AppStateUpdate::SelectedStrategy(
+                    strategy_name.clone(),
+                    MutexGuard::map(strategies_lock, |strategies| {
+                        strategies.get_mut(&strategy_name).expect("strategy exists")
+                    }),
+                    MutexGuard::map(
+                        app_state.available_strategies_contract_names.lock().await,
+                        |names| names.get_mut(&strategy_name).expect("inconsistent data"),
+                    ),
+                ))
             } else {
                 BackendEvent::None
             }
@@ -566,7 +515,8 @@ pub(crate) async fn run_strategy_task<'s>(
                         false,
                         Some(rs_sdk::platform::transition::put_settings::PutSettings {
                             request_settings: RequestSettings::default(),
-                            identity_nonce_stale_time_s: Some(1),
+                            identity_nonce_stale_time_s: Some(0),
+                            user_fee_increase: None,
                         }))
                     .await
                     .expect("Couldn't get current identity nonce");
@@ -580,7 +530,8 @@ pub(crate) async fn run_strategy_task<'s>(
                             false,
                             Some(rs_sdk::platform::transition::put_settings::PutSettings {
                                 request_settings: RequestSettings::default(),
-                                identity_nonce_stale_time_s: Some(1),
+                                identity_nonce_stale_time_s: Some(0),
+                                user_fee_increase: None,
                             })
                         )
                         .await
@@ -748,6 +699,14 @@ pub(crate) async fn run_strategy_task<'s>(
                     let mut rng = StdRng::from_entropy();
 
                     let mut known_contracts_lock = app_state.known_contracts.lock().await;
+
+                    // Log if you are creating start_identities, because the asset lock proofs may take a while
+                    if current_block_info.height == initial_block_info.height && strategy.start_identities.0 > 0 {
+                        info!(
+                            "Creating {} asset lock proofs for start identities",
+                            strategy.start_identities.0
+                        );
+                    }
 
                     // Call the function to get STs for block
                     let (transitions, finalize_operations) = strategy
@@ -1076,12 +1035,6 @@ pub(crate) async fn run_strategy_task<'s>(
                     current_block_info.time_ms += 1 * 1000; // plus 1 second
                 }
 
-                // Clear start_identities since they have now been registered, if any
-                if !strategy.start_identities.is_empty() {
-                    strategy.start_identities = Vec::new();
-                    info!("Strategy start_identities field cleared");
-                }
-
                 info!("-----Strategy '{}' finished running-----", strategy_name);
                 let run_time = run_start_time.elapsed();
 
@@ -1183,7 +1136,7 @@ pub(crate) async fn run_strategy_task<'s>(
         StrategyTask::RemoveStartIdentities(strategy_name) => {
             let mut strategies_lock = app_state.available_strategies.lock().await;
             if let Some(strategy) = strategies_lock.get_mut(&strategy_name) {
-                strategy.start_identities = vec![];
+                strategy.start_identities = (0, 0);
                 BackendEvent::AppStateUpdated(AppStateUpdate::SelectedStrategy(
                     strategy_name.clone(),
                     MutexGuard::map(strategies_lock, |strategies| {
@@ -1217,133 +1170,6 @@ pub(crate) async fn run_strategy_task<'s>(
             }
         }
     }
-}
-
-async fn set_start_identities(
-    count: u16,
-    key_count: u32,
-    signer: &mut SimpleSigner,
-    app_state: &AppState,
-    sdk: &Sdk,
-    insight: &InsightAPIClient,
-) -> Result<Vec<(Identity, StateTransition)>, Error> {
-    // Lock the loaded wallet.
-    let mut loaded_wallet = app_state.loaded_wallet.lock().await;
-
-    // Refresh UTXOs for the loaded wallet
-    if let Some(ref mut wallet) = *loaded_wallet {
-        wallet.reload_utxos(insight).await;
-    }
-
-    // Clone wallet state
-    let wallet_clone = loaded_wallet.clone().ok_or_else(|| {
-        Error::WalletError(super::wallet::WalletError::Insight(InsightError(
-            "No wallet loaded".to_string(),
-        )))
-    })?;
-
-    // Create a reference-counted, thread-safe clone of the wallet for the asset
-    // lock callback.
-    let wallet_ref = Arc::new(Mutex::new(wallet_clone));
-
-    // Define the asset lock callback.
-    let mut create_asset_lock = move |amount: u64| -> Option<(AssetLockProof, PrivateKey)> {
-        let wallet_clone = wallet_ref.clone();
-
-        // Use block_in_place to execute the async code synchronously.
-        tokio::task::block_in_place(|| {
-            let rt = tokio::runtime::Runtime::new().unwrap();
-            rt.block_on(async move {
-                let mut wallet = wallet_clone.lock().await;
-
-                // Initialize old_utxos
-                let old_utxos = match &*wallet {
-                    Wallet::SingleKeyWallet(wallet) => wallet.utxos.clone(),
-                };
-
-                match wallet.asset_lock_transaction(None, amount) {
-                    Ok((asset_lock_transaction, asset_lock_proof_private_key)) => {
-                        match AppState::broadcast_and_retrieve_asset_lock(
-                            sdk,
-                            &asset_lock_transaction,
-                            &wallet.receive_address(),
-                        )
-                        .await
-                        {
-                            Ok(proof) => {
-                                // Implement retry logic for reloading UTXOs
-                                let max_retries = 5;
-                                let mut retries = 0;
-                                let mut found_new_utxos = false;
-
-                                while retries < max_retries {
-                                    wallet.reload_utxos(insight).await;
-
-                                    let current_utxos = match &*wallet {
-                                        Wallet::SingleKeyWallet(wallet) => &wallet.utxos,
-                                    };
-                                    if current_utxos != &old_utxos && !current_utxos.is_empty() {
-                                        found_new_utxos = true;
-                                        break;
-                                    } else {
-                                        retries += 1;
-                                        tokio::time::sleep(tokio::time::Duration::from_secs(10))
-                                            .await;
-                                    }
-                                }
-
-                                if !found_new_utxos {
-                                    error!("Failed to find new UTXOs after maximum retries");
-                                    None
-                                } else {
-                                    Some((proof, asset_lock_proof_private_key))
-                                }
-                            }
-                            Err(e) => {
-                                error!("Error during asset lock transaction: {:?}", e);
-                                None
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        error!("Error initiating asset lock transaction: {:?}", e);
-                        match e {
-                            WalletError::Balance => {
-                                error!("Insufficient balance for asset lock transaction.");
-                            }
-                            _ => error!("Other wallet error occurred."),
-                        }
-                        None
-                    }
-                }
-            })
-        })
-    };
-
-    // Create identities and state transitions.
-    let identities_and_transitions_result = create_identities_state_transitions(
-        count,
-        key_count,
-        signer,
-        &mut StdRng::from_entropy(),
-        &mut create_asset_lock,
-        PlatformVersion::latest(),
-    );
-
-    drop(loaded_wallet);
-
-    // Check and reload UTXOs after the asset lock transactions, if successful.
-    if identities_and_transitions_result.is_ok() {
-        let mut loaded_wallet = app_state.loaded_wallet.lock().await;
-        if let Some(ref mut wallet) = *loaded_wallet {
-            if let Err(e) = reload_wallet_utxos(wallet, insight).await {
-                error!("Error reloading wallet UTXOs after asset lock: {:?}", e);
-                return Err(e);
-            }
-        }
-    }
-
-    Ok(identities_and_transitions_result?)
 }
 
 async fn reload_wallet_utxos(wallet: &mut Wallet, insight: &InsightAPIClient) -> Result<(), Error> {
@@ -1412,32 +1238,3 @@ pub async fn update_known_contracts(
 
     Ok(())
 }
-
-// // Function to fetch current blockchain height
-// async fn fetch_current_blockchain_height(sdk: &Sdk) -> Result<u64, String> {
-//     let request = GetEpochsInfoRequest {
-//         version: Some(get_epochs_info_request::Version::V0(
-//             get_epochs_info_request::GetEpochsInfoRequestV0 {
-//                 start_epoch: None,
-//                 count: 1,
-//                 ascending: false,
-//                 prove: false,
-//             },
-//         )),
-//     };
-
-//     match sdk.execute(request, RequestSettings::default()).await {
-//         Ok(response) => {
-//             if let Some(get_epochs_info_response::Version::V0(response_v0)) =
-// response.version {                 if let Some(metadata) =
-// response_v0.metadata {                     Ok(metadata.height)
-//                 } else {
-//                     Err("Failed to get blockchain height: No metadata
-// available".to_string())                 }
-//             } else {
-//                 Err("Failed to get blockchain height: Incorrect response
-// format".to_string())             }
-//         },
-//         Err(e) => Err(format!("Failed to get blockchain height: {:?}", e)),
-//     }
-// }

--- a/src/ui/views/strategies/selected_strategy.rs
+++ b/src/ui/views/strategies/selected_strategy.rs
@@ -265,6 +265,6 @@ fn display_strategy(
     Operations:
 {operations_lines}
     Start identities: {}"#,
-        strategy.start_identities.len()
+        strategy.start_identities.0
     )
 }

--- a/src/ui/views/strategies/start_identities.rs
+++ b/src/ui/views/strategies/start_identities.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 pub(super) struct StrategyStartIdentitiesFormController {
-    input: ComposedInput<(Field<SelectInput<u16>>, Field<SelectInput<u32>>)>,
+    input: ComposedInput<(Field<SelectInput<u8>>, Field<SelectInput<u8>>)>,
     selected_strategy: String,
 }
 
@@ -33,13 +33,13 @@ impl StrategyStartIdentitiesFormController {
 impl FormController for StrategyStartIdentitiesFormController {
     fn on_event(&mut self, event: KeyEvent) -> FormStatus {
         match self.input.on_event(event) {
-            InputStatus::Done((count, key_count)) => FormStatus::Done {
+            InputStatus::Done((count, keys_count)) => FormStatus::Done {
                 task: Task::Strategy(StrategyTask::SetStartIdentities {
                     strategy_name: self.selected_strategy.clone(),
                     count,
-                    key_count,
+                    keys_count,
                 }),
-                block: true,
+                block: false,
             },
             status => status.into(),
         }

--- a/src/ui/views/strategies/start_identities_screen.rs
+++ b/src/ui/views/strategies/start_identities_screen.rs
@@ -139,7 +139,7 @@ impl ScreenController for StartIdentitiesScreenController {
         let display_text = if let Some(strategy) = &self.selected_strategy {
             // Construct the text to display start identities
             let start_identities_text =
-                format!("Start identities: {}", strategy.start_identities.len());
+                format!("Start identities: {}", strategy.start_identities.0);
 
             format!(
                 "Strategy: {}\n{}",


### PR DESCRIPTION
Just passing `PutSettings` to `get_identity_nonce` and `get_identity_contract_nonce` to force sdk to read from Platform instead of internal cache, which was not being updated with the correct nonces between strategy tests.