### PR TITLE
feat: import and export strategies to and from Github

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -14,7 +14,6 @@ pub mod wallet;
 use std::{
     collections::BTreeMap,
     fmt::{self, Display},
-    sync::Arc,
     time::Duration,
 };
 
@@ -27,7 +26,7 @@ use rs_sdk::Sdk;
 use serde::Serialize;
 pub(crate) use state::AppState;
 use strategy_tests::Strategy;
-use tokio::sync::{MappedMutexGuard, Mutex, MutexGuard};
+use tokio::sync::{MappedMutexGuard, MutexGuard};
 
 use self::state::KnownContractsMap;
 pub(crate) use self::{

--- a/src/backend/state.rs
+++ b/src/backend/state.rs
@@ -23,7 +23,7 @@ use dpp::{
     version::PlatformVersion,
     ProtocolError::{self, PlatformDeserializationError, PlatformSerializationError},
 };
-use drive::drive::{Drive, RootTree};
+use drive::drive::Drive;
 use strategy_tests::Strategy;
 use tokio::sync::Mutex;
 use walkdir::{DirEntry, WalkDir};
@@ -33,7 +33,7 @@ use crate::{backend::insight::InsightAPIClient, config::Config};
 
 const CURRENT_PROTOCOL_VERSION: ProtocolVersion = 1;
 
-const USE_LOCAL: bool = false;
+const _USE_LOCAL: bool = false;
 
 pub(crate) type ContractFileName = String;
 
@@ -103,7 +103,7 @@ impl Default for AppState {
             }
         }
 
-        let (drive, protocol_version) =
+        let (drive, _protocol_version) =
             Drive::open("explorer.drive", None).expect("expected to open Drive successfully");
 
         if drive
@@ -381,7 +381,7 @@ impl PlatformDeserializableWithPotentialValidationFromVersionedStructure for App
                 )
             });
 
-        let (drive, protocol_version) =
+        let (drive, _protocol_version) =
             Drive::open("explorer.drive", None).expect("expected to open Drive successfully");
 
         // Deserialize the wallet state and wrap it in Arc<Mutex<_>>

--- a/src/bin/load_test.rs
+++ b/src/bin/load_test.rs
@@ -54,7 +54,7 @@ use rs_sdk::{
         transition::{put_document::PutDocument, put_settings::PutSettings},
         Fetch, Identifier,
     },
-    Error, Sdk, SdkBuilder,
+    Sdk, SdkBuilder,
 };
 use simple_signer::signer::SimpleSigner;
 use tokio::{sync::Semaphore, time::Instant};
@@ -226,7 +226,7 @@ async fn main() {
         }
     }
 
-    let mut credits_balance = backend
+    let credits_balance = backend
         .state()
         .loaded_identity
         .lock()
@@ -644,6 +644,7 @@ async fn broadcast_random_documents_load_test(
                         Some(PutSettings {
                             request_settings: settings,
                             identity_nonce_stale_time_s: None,
+                            user_fee_increase: None,
                         }),
                     )
                     .await;

--- a/src/ui/views/strategies.rs
+++ b/src/ui/views/strategies.rs
@@ -6,6 +6,7 @@ mod contracts_with_updates_screen;
 mod delete_strategy;
 mod identity_inserts;
 mod identity_inserts_screen;
+mod import_strategy;
 mod new_strategy;
 mod operations;
 mod operations_screen;
@@ -23,9 +24,11 @@ use tuirealm::{
 };
 
 use self::{
-    delete_strategy::DeleteStrategyFormController, new_strategy::NewStrategyFormController,
+    delete_strategy::DeleteStrategyFormController,
+    import_strategy::ImportStrategyFormController,
+    new_strategy::NewStrategyFormController,
     select_strategy::SelectStrategyFormController,
-    selected_strategy::SelectedStrategyScreenController,
+    selected_strategy::SelectedStrategyScreenController
 };
 use crate::{
     backend::{AppState, AppStateUpdate, BackendEvent},
@@ -36,9 +39,10 @@ use crate::{
     Event,
 };
 
-const COMMAND_KEYS: [ScreenCommandKey; 4] = [
+const COMMAND_KEYS: [ScreenCommandKey; 5] = [
     ScreenCommandKey::new("q", "Back to Main"),
     ScreenCommandKey::new("n", "New strategy"),
+    ScreenCommandKey::new("i", "Import a strategy"),
     ScreenCommandKey::new("s", "Select a strategy"),
     ScreenCommandKey::new("d", "Delete a strategy"),
 ];
@@ -81,7 +85,7 @@ impl ScreenController for StrategiesScreenController {
 
     fn command_keys(&self) -> &[ScreenCommandKey] {
         if self.available_strategies.is_empty() {
-            &COMMAND_KEYS[..2] // Exclude Delete and Select when no strategies
+            &COMMAND_KEYS[..3] // Exclude Delete and Select when no strategies
                                // loaded
         } else {
             COMMAND_KEYS.as_ref()
@@ -103,6 +107,13 @@ impl ScreenController for StrategiesScreenController {
                 modifiers: KeyModifiers::NONE,
             }) => ScreenFeedback::FormThenNextScreen {
                 form: Box::new(NewStrategyFormController::new()),
+                screen: SelectedStrategyScreenController::builder(),
+            },
+            Event::Key(KeyEvent {
+                code: Key::Char('i'),
+                modifiers: KeyModifiers::NONE,
+            }) => ScreenFeedback::FormThenNextScreen {
+                form: Box::new(ImportStrategyFormController::new()),
                 screen: SelectedStrategyScreenController::builder(),
             },
             Event::Key(KeyEvent {

--- a/src/ui/views/strategies.rs
+++ b/src/ui/views/strategies.rs
@@ -7,6 +7,7 @@ mod delete_strategy;
 mod identity_inserts;
 mod identity_inserts_screen;
 mod import_strategy;
+mod export_strategy;
 mod new_strategy;
 mod operations;
 mod operations_screen;
@@ -26,6 +27,7 @@ use tuirealm::{
 use self::{
     delete_strategy::DeleteStrategyFormController,
     import_strategy::ImportStrategyFormController,
+    export_strategy::ExportStrategyFormController,
     new_strategy::NewStrategyFormController,
     select_strategy::SelectStrategyFormController,
     selected_strategy::SelectedStrategyScreenController
@@ -39,10 +41,11 @@ use crate::{
     Event,
 };
 
-const COMMAND_KEYS: [ScreenCommandKey; 5] = [
+const COMMAND_KEYS: [ScreenCommandKey; 6] = [
     ScreenCommandKey::new("q", "Back to Main"),
     ScreenCommandKey::new("n", "New strategy"),
     ScreenCommandKey::new("i", "Import a strategy"),
+    ScreenCommandKey::new("e", "Export a strategy"),
     ScreenCommandKey::new("s", "Select a strategy"),
     ScreenCommandKey::new("d", "Delete a strategy"),
 ];
@@ -85,8 +88,7 @@ impl ScreenController for StrategiesScreenController {
 
     fn command_keys(&self) -> &[ScreenCommandKey] {
         if self.available_strategies.is_empty() {
-            &COMMAND_KEYS[..3] // Exclude Delete and Select when no strategies
-                               // loaded
+            &COMMAND_KEYS[..3] // Exclude certain operations when there are no available strategies
         } else {
             COMMAND_KEYS.as_ref()
         }
@@ -117,6 +119,16 @@ impl ScreenController for StrategiesScreenController {
                 screen: SelectedStrategyScreenController::builder(),
             },
             Event::Key(KeyEvent {
+                code: Key::Char('e'),
+                modifiers: KeyModifiers::NONE,
+            }) => {
+                if !self.available_strategies.is_empty() {
+                    ScreenFeedback::Form(Box::new(ExportStrategyFormController::new(self.available_strategies.clone())))
+                } else {
+                    ScreenFeedback::None
+                }
+            }
+            Event::Key(KeyEvent {
                 code: Key::Char('s'),
                 modifiers: KeyModifiers::NONE,
             }) => {
@@ -128,8 +140,7 @@ impl ScreenController for StrategiesScreenController {
                         screen: SelectedStrategyScreenController::builder(),
                     }
                 } else {
-                    ScreenFeedback::None // Do nothing if there are no available
-                                         // strategies
+                    ScreenFeedback::None
                 }
             }
             Event::Key(KeyEvent {
@@ -141,8 +152,7 @@ impl ScreenController for StrategiesScreenController {
                         self.available_strategies.clone(),
                     )))
                 } else {
-                    ScreenFeedback::None // Do nothing if there are no available
-                                         // strategies
+                    ScreenFeedback::None
                 }
             }
             Event::Backend(

--- a/src/ui/views/strategies/export_strategy.rs
+++ b/src/ui/views/strategies/export_strategy.rs
@@ -1,0 +1,53 @@
+//! Strategy export-to-file form and screen.
+
+use tuirealm::{event::KeyEvent, tui::prelude::Rect, Frame};
+
+use crate::{
+    backend::{StrategyTask, Task},
+    ui::form::{FormController, FormStatus, Input, InputStatus, SelectInput},
+};
+
+pub(super) struct ExportStrategyFormController {
+    input: SelectInput<String>,
+}
+
+impl ExportStrategyFormController {
+    pub(super) fn new(strategies: Vec<String>) -> Self {
+        Self {
+            input: SelectInput::new(strategies),
+        }
+    }
+}
+
+impl FormController for ExportStrategyFormController {
+    fn on_event(&mut self, event: KeyEvent) -> FormStatus {
+        match self.input.on_event(event) {
+            InputStatus::Done(strategy_name) => FormStatus::Done {
+                task: Task::Strategy(StrategyTask::ExportStrategy(strategy_name)),
+                block: false,
+            },
+            InputStatus::Exit => FormStatus::Exit,
+            status => status.into(),
+        }
+    }
+
+    fn form_name(&self) -> &'static str {
+        "Strategy export"
+    }
+
+    fn step_view(&mut self, frame: &mut Frame, area: Rect) {
+        self.input.view(frame, area)
+    }
+
+    fn step_name(&self) -> &'static str {
+        ""
+    }
+
+    fn step_index(&self) -> u8 {
+        0
+    }
+
+    fn steps_number(&self) -> u8 {
+        1
+    }
+}

--- a/src/ui/views/strategies/import_strategy.rs
+++ b/src/ui/views/strategies/import_strategy.rs
@@ -1,0 +1,54 @@
+//! Form to import a Strategy from Github via URL.
+
+use tuirealm::{event::KeyEvent, tui::prelude::Rect, Frame};
+
+use crate::{
+    backend::{StrategyTask, Task},
+    ui::form::{
+        parsers::DefaultTextInputParser, FormController, FormStatus, Input, InputStatus, TextInput,
+    },
+};
+
+pub(crate) struct ImportStrategyFormController {
+    input: TextInput<DefaultTextInputParser<String>>,
+}
+
+impl ImportStrategyFormController {
+    pub(crate) fn new() -> Self {
+        Self {
+            input: TextInput::new("Github file URL"),
+        }
+    }
+}
+
+impl FormController for ImportStrategyFormController {
+    fn on_event(&mut self, event: KeyEvent) -> FormStatus {
+        match self.input.on_event(event) {
+            InputStatus::Done(url) => FormStatus::Done {
+                task: Task::Strategy(StrategyTask::ImportStrategy(url)),
+                block: false,
+            },
+            status => status.into(),
+        }
+    }
+
+    fn form_name(&self) -> &'static str {
+        "Import strategy"
+    }
+
+    fn step_view(&mut self, frame: &mut Frame, area: Rect) {
+        self.input.view(frame, area)
+    }
+
+    fn step_name(&self) -> &'static str {
+        "Url"
+    }
+
+    fn step_index(&self) -> u8 {
+        0
+    }
+
+    fn steps_number(&self) -> u8 {
+        1
+    }
+}

--- a/src/ui/views/strategies/import_strategy.rs
+++ b/src/ui/views/strategies/import_strategy.rs
@@ -16,7 +16,7 @@ pub(crate) struct ImportStrategyFormController {
 impl ImportStrategyFormController {
     pub(crate) fn new() -> Self {
         Self {
-            input: TextInput::new("Raw Github file URL (ex: https://raw.githubusercontent.com/pauldelucia/dash-platform-strategy-tests/main/demo.json)"),
+            input: TextInput::new("Raw Github file URL (ex: https://raw.githubusercontent.com/pauldelucia/dash-platform-strategy-tests/main/example)"),
         }
     }
 }

--- a/src/ui/views/strategies/import_strategy.rs
+++ b/src/ui/views/strategies/import_strategy.rs
@@ -16,7 +16,7 @@ pub(crate) struct ImportStrategyFormController {
 impl ImportStrategyFormController {
     pub(crate) fn new() -> Self {
         Self {
-            input: TextInput::new("Github file URL"),
+            input: TextInput::new("Raw Github file URL (ex: https://raw.githubusercontent.com/pauldelucia/dash-platform-strategy-tests/main/demo.json)"),
         }
     }
 }


### PR DESCRIPTION
Users can paste the url of raw Github files into the explorer to import a strategy, and they can export them to a file in `supporting_files/strategy_exports` and then manually add them to Github repositories.