### PR TITLE
fix: a few fixes in strategy tests

### DIFF
--- a/src/backend/strategies.rs
+++ b/src/backend/strategies.rs
@@ -287,11 +287,11 @@ pub(crate) async fn run_strategy_task<'s>(
             }
         }
         StrategyTask::SetContractsWithUpdates(strategy_name, selected_contract_names) => {
+            // Attain state locks
             let mut strategies_lock = app_state.available_strategies.lock().await;
             let known_contracts_lock = app_state.known_contracts.lock().await;
             let supporting_contracts_lock = app_state.supporting_contracts.lock().await;
-            let mut contract_names_lock =
-                app_state.available_strategies_contract_names.lock().await;
+            let mut contract_names_lock = app_state.available_strategies_contract_names.lock().await;
 
             if let Some(strategy) = strategies_lock.get_mut(&strategy_name) {
                 let platform_version = PlatformVersion::latest();
@@ -305,27 +305,11 @@ pub(crate) async fn run_strategy_task<'s>(
                         .cloned()
                 };
 
-                // Get the loaded identity nonce
-                let loaded_identity_lock = match app_state.refresh_identity(&sdk).await {
-                    Ok(lock) => lock,
-                    Err(e) => {
-                        error!("Failed to refresh identity: {:?}", e);
-                        return BackendEvent::StrategyError {
-                            strategy_name: strategy_name.clone(),
-                            error: format!("Failed to refresh identity: {:?}", e),
-                        };
-                    }
-                };
-                let identity_nonce = sdk
-                    .get_identity_nonce(loaded_identity_lock.id(), true, None)
-                    .await
-                    .expect("Couldn't get current identity nonce");
-
                 if let Some(first_contract_name) = selected_contract_names.first() {
                     if let Some(data_contract) = get_contract(first_contract_name) {
                         match CreatedDataContract::from_contract_and_identity_nonce(
                             data_contract,
-                            identity_nonce,
+                            u64::default(),
                             platform_version,
                         ) {
                             Ok(initial_contract) => {
@@ -337,7 +321,7 @@ pub(crate) async fn run_strategy_task<'s>(
                                     if let Some(update_contract) = get_contract(contract_name) {
                                         match CreatedDataContract::from_contract_and_identity_nonce(
                                             update_contract,
-                                            identity_nonce,
+                                            u64::default(),
                                             platform_version,
                                         ) {
                                             Ok(created_update_contract) => {
@@ -1029,7 +1013,6 @@ pub(crate) async fn run_strategy_task<'s>(
                                                 }
                                             })
                                         },
-                                        // Handle other state transition types that involve data contracts here
                                         _ => None,
                                     };
 
@@ -1078,7 +1061,50 @@ pub(crate) async fn run_strategy_task<'s>(
                                                             _ => {
                                                                 // nothing
                                                             }
-                                                        }                                                        
+                                                        }
+
+                                                        // If a data contract was registered, add it to
+                                                        // known_contracts
+                                                        if let StateTransition::DataContractCreate(
+                                                            DataContractCreateTransition::V0(
+                                                                data_contract_create_transition,
+                                                            ),
+                                                        ) = &transition
+                                                        {
+                                                            // Extract the data contract from the transition
+                                                            let data_contract_serialized =
+                                                                &data_contract_create_transition
+                                                                    .data_contract;
+                                                            let data_contract_result =
+                                                                DataContract::try_from_platform_versioned(
+                                                                    data_contract_serialized.clone(),
+                                                                    false,
+                                                                    PlatformVersion::latest(),
+                                                                );
+
+                                                            match data_contract_result {
+                                                                Ok(data_contract) => {
+                                                                    let mut known_contracts_lock =
+                                                                        app_state
+                                                                            .known_contracts
+                                                                            .lock()
+                                                                            .await;
+                                                                    known_contracts_lock.insert(
+                                                                        data_contract
+                                                                            .id()
+                                                                            .to_string(Encoding::Base58),
+                                                                        data_contract,
+                                                                    );
+                                                                }
+                                                                Err(e) => {
+                                                                    error!(
+                                                                        "Error deserializing data \
+                                                                        contract: {:?}",
+                                                                        e
+                                                                    );
+                                                                }
+                                                            }
+                                                        }
 
                                                         // Verification of the proof
                                                         if let Some(wait_for_state_transition_result_response_v0::Result::Proof(proof)) = &v0_response.result {
@@ -1106,52 +1132,7 @@ pub(crate) async fn run_strategy_task<'s>(
                                                                 };
 
                                                                 match verified {
-                                                                    Ok(_) => {
-                                                                        info!("Verified proof for state transition {} ({}) for block {} (Actual block height: {})", index + 1, transition_type, current_block_info.height, actual_block_height);
-                                                                        
-                                                                        // If a data contract was registered, add it to
-                                                                        // known_contracts
-                                                                        if let StateTransition::DataContractCreate(
-                                                                            DataContractCreateTransition::V0(
-                                                                                data_contract_create_transition,
-                                                                            ),
-                                                                        ) = &transition
-                                                                        {
-                                                                            // Extract the data contract from the transition
-                                                                            let data_contract_serialized =
-                                                                                &data_contract_create_transition
-                                                                                    .data_contract;
-                                                                            let data_contract_result =
-                                                                                DataContract::try_from_platform_versioned(
-                                                                                    data_contract_serialized.clone(),
-                                                                                    false,
-                                                                                    PlatformVersion::latest(),
-                                                                                );
-
-                                                                            match data_contract_result {
-                                                                                Ok(data_contract) => {
-                                                                                    let mut known_contracts_lock =
-                                                                                        app_state
-                                                                                            .known_contracts
-                                                                                            .lock()
-                                                                                            .await;
-                                                                                    known_contracts_lock.insert(
-                                                                                        data_contract
-                                                                                            .id()
-                                                                                            .to_string(Encoding::Base58),
-                                                                                        data_contract,
-                                                                                    );
-                                                                                }
-                                                                                Err(e) => {
-                                                                                    error!(
-                                                                                        "Error deserializing data \
-                                                                                        contract: {:?}",
-                                                                                        e
-                                                                                    );
-                                                                                }
-                                                                            }
-                                                                        }
-                                                                    }
+                                                                    Ok(_) => info!("Verified proof for state transition {} ({}) for block {} (Actual block height: {})", index + 1, transition_type, current_block_info.height, actual_block_height),
                                                                     Err(e) => error!("Error verifying state transition execution proof: {}", e),
                                                                 }
                                                             }

--- a/src/ui/views/strategies/operations.rs
+++ b/src/ui/views/strategies/operations.rs
@@ -12,14 +12,13 @@ mod identity_withdrawal;
 use std::collections::BTreeMap;
 
 use rs_sdk::platform::DataContract;
-use strum::IntoEnumIterator;
 use tracing::error;
 use tuirealm::{event::KeyEvent, tui::prelude::Rect, Frame};
 
 use self::{
     contract_create::StrategyOpContractCreateFormController, contract_update_doc_types::StrategyOpContractUpdateDocTypesFormController, document::StrategyOpDocumentFormController, identity_top_up::StrategyOpIdentityTopUpFormController, identity_transfer::StrategyOpIdentityTransferFormController, identity_update::StrategyOpIdentityUpdateFormController, identity_withdrawal::StrategyOpIdentityWithdrawalFormController
 };
-use crate::ui::form::{FormController, FormStatus, Input, InputStatus, SelectInput};
+use crate::{backend::StrategyContractNames, ui::form::{FormController, FormStatus, Input, InputStatus, SelectInput}};
 
 #[derive(Debug, strum::Display, Clone, strum::EnumIter, Copy)]
 enum OperationType {
@@ -40,6 +39,7 @@ pub(super) struct StrategyAddOperationFormController {
     strategy_name: String,
     known_contracts: BTreeMap<String, DataContract>,
     supporting_contracts: BTreeMap<String, DataContract>,
+    strategy_contract_names: StrategyContractNames,
 }
 
 impl StrategyAddOperationFormController {
@@ -47,6 +47,7 @@ impl StrategyAddOperationFormController {
         strategy_name: String,
         known_contracts: BTreeMap<String, DataContract>,
         supporting_contracts: BTreeMap<String, DataContract>,
+        strategy_contract_names: StrategyContractNames,
     ) -> Self {
         let operation_types = vec![
             "Document".to_string(),
@@ -65,6 +66,7 @@ impl StrategyAddOperationFormController {
             strategy_name,
             known_contracts,
             supporting_contracts,
+            strategy_contract_names,
         }
     }
 
@@ -74,6 +76,7 @@ impl StrategyAddOperationFormController {
                 self.strategy_name.clone(),
                 self.known_contracts.clone(),
                 self.supporting_contracts.clone(),
+                self.strategy_contract_names.clone(),
             )),
             OperationType::IdentityTopUp => Box::new(StrategyOpIdentityTopUpFormController::new(
                 self.strategy_name.clone(),

--- a/src/ui/views/strategies/operations/document.rs
+++ b/src/ui/views/strategies/operations/document.rs
@@ -9,17 +9,15 @@ use dpp::data_contract::{
         DocumentType,
     },
 };
-use drive::drive::contract;
 use rs_sdk::platform::DataContract;
 use strategy_tests::{
     frequency::Frequency,
     operations::{DocumentAction, DocumentOp, Operation, OperationType},
 };
-use tracing::info;
 use tuirealm::{event::KeyEvent, tui::prelude::Rect, Frame};
 
 use crate::{
-    backend::{StrategyTask, Task},
+    backend::{StrategyContractNames, StrategyTask, Task},
     ui::form::{ComposedInput, Field, FormController, FormStatus, Input, InputStatus, SelectInput},
 };
 
@@ -30,22 +28,39 @@ pub(super) struct StrategyOpDocumentFormController {
         Field<SelectInput<u16>>,
         Field<SelectInput<f64>>,
     )>,
-    selected_strategy: String,
+    selected_strategy_name: String,
     known_contracts: BTreeMap<String, DataContract>,
     supporting_contracts: BTreeMap<String, DataContract>,
     document_types: BTreeMap<String, DocumentType>,
+    strategy_contract_names: StrategyContractNames,
 }
 
 impl StrategyOpDocumentFormController {
     pub(super) fn new(
-        selected_strategy: String,
+        selected_strategy_name: String,
         known_contracts: BTreeMap<String, DataContract>,
         supporting_contracts: BTreeMap<String, DataContract>,
+        strategy_contract_names: StrategyContractNames,
     ) -> Self {
         // Collect known_contracts and supporting_contracts names for the form
         let mut contract_names: Vec<String> = known_contracts.keys().cloned().collect();
-        contract_names.extend(supporting_contracts.keys().cloned());
 
+        // Add only supporting contracts that are also in strategy_contract_names
+        for (supporting_contract_name, _) in supporting_contracts.iter() {
+            if strategy_contract_names.iter().any(|(name, _)| name == supporting_contract_name) {
+                contract_names.push(supporting_contract_name.clone());
+            }
+        }
+
+        // Flatten the nested structure of strategy_contract_names and add to contract_names
+        for (_, optional_map) in strategy_contract_names.iter() {
+            if let Some(map) = optional_map {
+                for (_, contract_name) in map.iter() {
+                    contract_names.push(contract_name.clone());
+                }
+            }
+        }
+        
         // Remove duplicates
         let contract_names: Vec<String> = contract_names.into_iter().collect::<std::collections::HashSet<_>>().into_iter().collect();
 
@@ -68,10 +83,11 @@ impl StrategyOpDocumentFormController {
                     SelectInput::new(vec![1.0, 0.75, 0.5, 0.25, 0.1]),
                 ),
             )),
-            selected_strategy,
+            selected_strategy_name,
             known_contracts,
             supporting_contracts,
             document_types: BTreeMap::new(),
+            strategy_contract_names,
         }
     }
 }
@@ -103,7 +119,7 @@ impl FormController for StrategyOpDocumentFormController {
 
                 FormStatus::Done {
                     task: Task::Strategy(StrategyTask::AddOperation {
-                        strategy_name: self.selected_strategy.clone(),
+                        strategy_name: self.selected_strategy_name.clone(),
                         operation: Operation {
                             op_type: OperationType::Document(DocumentOp {
                                 contract: selected_contract.clone(),

--- a/src/ui/views/strategies/operations_screen.rs
+++ b/src/ui/views/strategies/operations_screen.rs
@@ -151,10 +151,14 @@ impl ScreenController for OperationsScreenController {
                     // Update known contracts before showing the form
                     self.update_supporting_contracts_sync();
 
+                    let strategy_contract_names = self.strategy_contract_names.get(&strategy_name)
+                        .expect("Expected to get strategy contract names in operations screen");
+
                     ScreenFeedback::Form(Box::new(StrategyAddOperationFormController::new(
                         strategy_name.clone(),
                         self.known_contracts.clone(),
                         self.supporting_contracts.clone(),
+                        strategy_contract_names.to_vec(),
                     )))
                 } else {
                     ScreenFeedback::None


### PR DESCRIPTION
- we were fetching the identity contract nonce when setting contracts_with_updates when we didn't need to be, because we set it later in strategy execution anyways. just set u64::default().
- in addition to the known_contracts, only display the the supporting_contracts that were already present in contracts_with_updates when selecting a contract to register documents to
- mistakenly was only adding registered contracts to known_contracts if we were verifying ST proofs, but we want to do it also if we're not verifying