### PR TITLE
feat: updates for v1.0.0-dev.12 compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,8 +997,8 @@ dependencies = [
 
 [[package]]
 name = "dapi-grpc"
-version = "1.0.0-dev.11"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.11#5d51032ca5781a1324d1f5c3c4a7b4001a3547df"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.12#6de96cdb0c5b029bed60f04fe83ac5ae1137c6ac"
 dependencies = [
  "dapi-grpc-macros",
  "futures-core",
@@ -1014,8 +1014,8 @@ dependencies = [
 
 [[package]]
 name = "dapi-grpc-macros"
-version = "1.0.0-dev.11"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.11#5d51032ca5781a1324d1f5c3c4a7b4001a3547df"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.12#6de96cdb0c5b029bed60f04fe83ac5ae1137c6ac"
 dependencies = [
  "heck 0.5.0",
  "quote",
@@ -1059,8 +1059,8 @@ dependencies = [
 
 [[package]]
 name = "dash-sdk"
-version = "1.0.0-dev.11"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.11#5d51032ca5781a1324d1f5c3c4a7b4001a3547df"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.12#6de96cdb0c5b029bed60f04fe83ac5ae1137c6ac"
 dependencies = [
  "async-trait",
  "bincode",
@@ -1164,8 +1164,8 @@ dependencies = [
 
 [[package]]
 name = "dashpay-contract"
-version = "1.0.0-dev.11"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.11#5d51032ca5781a1324d1f5c3c4a7b4001a3547df"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.12#6de96cdb0c5b029bed60f04fe83ac5ae1137c6ac"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -1175,8 +1175,8 @@ dependencies = [
 
 [[package]]
 name = "data-contracts"
-version = "1.0.0-dev.11"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.11#5d51032ca5781a1324d1f5c3c4a7b4001a3547df"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.12#6de96cdb0c5b029bed60f04fe83ac5ae1137c6ac"
 dependencies = [
  "dashpay-contract",
  "dpns-contract",
@@ -1257,8 +1257,8 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpns-contract"
-version = "1.0.0-dev.11"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.11#5d51032ca5781a1324d1f5c3c4a7b4001a3547df"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.12#6de96cdb0c5b029bed60f04fe83ac5ae1137c6ac"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -1268,8 +1268,8 @@ dependencies = [
 
 [[package]]
 name = "dpp"
-version = "1.0.0-dev.11"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.11#5d51032ca5781a1324d1f5c3c4a7b4001a3547df"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.12#6de96cdb0c5b029bed60f04fe83ac5ae1137c6ac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1315,8 +1315,8 @@ dependencies = [
 
 [[package]]
 name = "drive"
-version = "1.0.0-dev.11"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.11#5d51032ca5781a1324d1f5c3c4a7b4001a3547df"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.12#6de96cdb0c5b029bed60f04fe83ac5ae1137c6ac"
 dependencies = [
  "arc-swap",
  "base64 0.21.7",
@@ -1350,8 +1350,8 @@ dependencies = [
 
 [[package]]
 name = "drive-proof-verifier"
-version = "1.0.0-dev.11"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.11#5d51032ca5781a1324d1f5c3c4a7b4001a3547df"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.12#6de96cdb0c5b029bed60f04fe83ac5ae1137c6ac"
 dependencies = [
  "dapi-grpc",
  "dpp",
@@ -1571,8 +1571,8 @@ checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "feature-flags-contract"
-version = "1.0.0-dev.11"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.11#5d51032ca5781a1324d1f5c3c4a7b4001a3547df"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.12#6de96cdb0c5b029bed60f04fe83ac5ae1137c6ac"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -1841,7 +1841,7 @@ dependencies = [
 [[package]]
 name = "grovedb"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/dashpay/grovedb?rev=f5a3382c5537de7417e983cdf2132792aa9fdc9d#f5a3382c5537de7417e983cdf2132792aa9fdc9d"
+source = "git+https://github.com/dashpay/grovedb?rev=d9292aa20bd8f3bda7c5d25d62db06ac341b0677#d9292aa20bd8f3bda7c5d25d62db06ac341b0677"
 dependencies = [
  "bincode",
  "grovedb-costs",
@@ -1862,7 +1862,7 @@ dependencies = [
 [[package]]
 name = "grovedb-costs"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/dashpay/grovedb?rev=f5a3382c5537de7417e983cdf2132792aa9fdc9d#f5a3382c5537de7417e983cdf2132792aa9fdc9d"
+source = "git+https://github.com/dashpay/grovedb?rev=d9292aa20bd8f3bda7c5d25d62db06ac341b0677#d9292aa20bd8f3bda7c5d25d62db06ac341b0677"
 dependencies = [
  "integer-encoding",
  "intmap",
@@ -1872,7 +1872,7 @@ dependencies = [
 [[package]]
 name = "grovedb-merk"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/dashpay/grovedb?rev=f5a3382c5537de7417e983cdf2132792aa9fdc9d#f5a3382c5537de7417e983cdf2132792aa9fdc9d"
+source = "git+https://github.com/dashpay/grovedb?rev=d9292aa20bd8f3bda7c5d25d62db06ac341b0677#d9292aa20bd8f3bda7c5d25d62db06ac341b0677"
 dependencies = [
  "blake3",
  "byteorder",
@@ -1895,12 +1895,12 @@ dependencies = [
 [[package]]
 name = "grovedb-path"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/dashpay/grovedb?rev=f5a3382c5537de7417e983cdf2132792aa9fdc9d#f5a3382c5537de7417e983cdf2132792aa9fdc9d"
+source = "git+https://github.com/dashpay/grovedb?rev=d9292aa20bd8f3bda7c5d25d62db06ac341b0677#d9292aa20bd8f3bda7c5d25d62db06ac341b0677"
 
 [[package]]
 name = "grovedb-storage"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/dashpay/grovedb?rev=f5a3382c5537de7417e983cdf2132792aa9fdc9d#f5a3382c5537de7417e983cdf2132792aa9fdc9d"
+source = "git+https://github.com/dashpay/grovedb?rev=d9292aa20bd8f3bda7c5d25d62db06ac341b0677#d9292aa20bd8f3bda7c5d25d62db06ac341b0677"
 dependencies = [
  "blake3",
  "grovedb-costs",
@@ -1919,7 +1919,7 @@ dependencies = [
 [[package]]
 name = "grovedb-visualize"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/dashpay/grovedb?rev=f5a3382c5537de7417e983cdf2132792aa9fdc9d#f5a3382c5537de7417e983cdf2132792aa9fdc9d"
+source = "git+https://github.com/dashpay/grovedb?rev=d9292aa20bd8f3bda7c5d25d62db06ac341b0677#d9292aa20bd8f3bda7c5d25d62db06ac341b0677"
 dependencies = [
  "hex",
  "itertools 0.12.1",
@@ -2398,8 +2398,8 @@ dependencies = [
 
 [[package]]
 name = "json-schema-compatibility-validator"
-version = "0.25.16-rc.3"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.11#5d51032ca5781a1324d1f5c3c4a7b4001a3547df"
+version = "0.25.16-rc.4"
+source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.12#6de96cdb0c5b029bed60f04fe83ac5ae1137c6ac"
 dependencies = [
  "json-patch",
  "once_cell",
@@ -2604,8 +2604,8 @@ dependencies = [
 
 [[package]]
 name = "masternode-reward-shares-contract"
-version = "1.0.0-dev.11"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.11#5d51032ca5781a1324d1f5c3c4a7b4001a3547df"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.12#6de96cdb0c5b029bed60f04fe83ac5ae1137c6ac"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -3150,8 +3150,8 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "platform-serialization"
-version = "1.0.0-dev.11"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.11#5d51032ca5781a1324d1f5c3c4a7b4001a3547df"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.12#6de96cdb0c5b029bed60f04fe83ac5ae1137c6ac"
 dependencies = [
  "bincode",
  "platform-version",
@@ -3159,8 +3159,8 @@ dependencies = [
 
 [[package]]
 name = "platform-serialization-derive"
-version = "1.0.0-dev.11"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.11#5d51032ca5781a1324d1f5c3c4a7b4001a3547df"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.12#6de96cdb0c5b029bed60f04fe83ac5ae1137c6ac"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3170,8 +3170,8 @@ dependencies = [
 
 [[package]]
 name = "platform-value"
-version = "1.0.0-dev.11"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.11#5d51032ca5781a1324d1f5c3c4a7b4001a3547df"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.12#6de96cdb0c5b029bed60f04fe83ac5ae1137c6ac"
 dependencies = [
  "base64 0.22.0",
  "bincode",
@@ -3192,16 +3192,16 @@ dependencies = [
 
 [[package]]
 name = "platform-version"
-version = "1.0.0-dev.11"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.11#5d51032ca5781a1324d1f5c3c4a7b4001a3547df"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.12#6de96cdb0c5b029bed60f04fe83ac5ae1137c6ac"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "platform-versioning"
-version = "1.0.0-dev.11"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.11#5d51032ca5781a1324d1f5c3c4a7b4001a3547df"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.12#6de96cdb0c5b029bed60f04fe83ac5ae1137c6ac"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3731,8 +3731,8 @@ dependencies = [
 
 [[package]]
 name = "rs-dapi-client"
-version = "1.0.0-dev.11"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.11#5d51032ca5781a1324d1f5c3c4a7b4001a3547df"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.12#6de96cdb0c5b029bed60f04fe83ac5ae1137c6ac"
 dependencies = [
  "backon",
  "chrono",
@@ -4207,8 +4207,8 @@ checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "simple-signer"
-version = "1.0.0-dev.11"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.11#5d51032ca5781a1324d1f5c3c4a7b4001a3547df"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.12#6de96cdb0c5b029bed60f04fe83ac5ae1137c6ac"
 dependencies = [
  "bincode",
  "dashcore-rpc",
@@ -4329,8 +4329,8 @@ checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
 name = "strategy-tests"
-version = "1.0.0-dev.11"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.11#5d51032ca5781a1324d1f5c3c4a7b4001a3547df"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.12#6de96cdb0c5b029bed60f04fe83ac5ae1137c6ac"
 dependencies = [
  "bincode",
  "dpp",
@@ -4829,6 +4829,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -5573,8 +5574,8 @@ dependencies = [
 
 [[package]]
 name = "withdrawals-contract"
-version = "1.0.0-dev.11"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.11#5d51032ca5781a1324d1f5c3c4a7b4001a3547df"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?tag=v1.0.0-dev.12#6de96cdb0c5b029bed60f04fe83ac5ae1137c6ac"
 dependencies = [
  "num_enum",
  "platform-value",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,23 +10,23 @@ strum = { version = "0.26.1", features = ["derive"] }
 tui-realm-stdlib = "1.3.1"
 tuirealm = "1.9.1"
 bs58 = "0.5.0"
-dpp = { git = "https://github.com/dashpay/platform", tag = "v1.0.0-dev.11", features = [
+dpp = { git = "https://github.com/dashpay/platform", tag = "v1.0.0-dev.12", features = [
     "client",
 ] }
-dash-sdk = { git = "https://github.com/dashpay/platform", tag = "v1.0.0-dev.11" }
-drive = { git = "https://github.com/dashpay/platform", tag = "v1.0.0-dev.11" }
+dash-sdk = { git = "https://github.com/dashpay/platform", tag = "v1.0.0-dev.12" }
+drive = { git = "https://github.com/dashpay/platform", tag = "v1.0.0-dev.12" }
 thiserror = "1"
 serde = "1.0.197"
 serde_json = "1.0.114"
 toml = { version = "0.8.10", features = ["display"] }
-dapi-grpc = { git = "https://github.com/dashpay/platform", tag = "v1.0.0-dev.11", features = [
+dapi-grpc = { git = "https://github.com/dashpay/platform", tag = "v1.0.0-dev.12", features = [
     "client",
 ] }
-rs-dapi-client = { git = "https://github.com/dashpay/platform", tag = "v1.0.0-dev.11" }
+rs-dapi-client = { git = "https://github.com/dashpay/platform", tag = "v1.0.0-dev.12" }
 tokio = { version = "1.36.0", features = ["full"] }
 bincode = { version = "2.0.0-rc.3", features = ["serde"] }
-strategy-tests = { git = "https://github.com/dashpay/platform", tag = "v1.0.0-dev.11" }
-simple-signer = { git = "https://github.com/dashpay/platform", tag = "v1.0.0-dev.11" }
+strategy-tests = { git = "https://github.com/dashpay/platform", tag = "v1.0.0-dev.12" }
+simple-signer = { git = "https://github.com/dashpay/platform", tag = "v1.0.0-dev.12" }
 reqwest = { version = "0.12.3", features = ["json"] }
 hex = { version = "0.4.3" }
 itertools = "0.12.1"

--- a/src/backend/identities.rs
+++ b/src/backend/identities.rs
@@ -7,11 +7,11 @@ use std::{
 
 use dapi_grpc::{
     core::v0::{
-        BroadcastTransactionRequest, GetStatusRequest, GetTransactionRequest,
+        BroadcastTransactionRequest, GetBlockchainStatusRequest, GetTransactionRequest,
         GetTransactionResponse,
     },
     platform::v0::{
-        get_identity_balance_request, get_identity_balance_request::GetIdentityBalanceRequestV0,
+        get_identity_balance_request::{self, GetIdentityBalanceRequestV0},
         GetIdentityBalanceRequest,
     },
 };
@@ -480,6 +480,7 @@ impl AppState {
                         KeyPurpose::TRANSFER,
                         KeySecurityLevel::CRITICAL,
                         KeyType::ECDSA_SECP256K1,
+                        None,
                         sdk.version(),
                     )?;
                 identity.add_public_key(transfer_key.clone());
@@ -747,7 +748,7 @@ impl AppState {
         .entered();
 
         let block_hash = sdk
-            .execute(GetStatusRequest {}, RequestSettings::default())
+            .execute(GetBlockchainStatusRequest {}, RequestSettings::default())
             .await?
             .chain
             .map(|chain| chain.best_block_hash)

--- a/src/ui/views/strategies/operations.rs
+++ b/src/ui/views/strategies/operations.rs
@@ -303,7 +303,7 @@ fn format_operation_name(op_type: &StrategyOperationType) -> String {
             let op_type = match op.action {
                 DocumentAction::DocumentActionInsertRandom(..) => "InsertRandom",
                 DocumentAction::DocumentActionDelete => "Delete",
-                DocumentAction::DocumentActionReplace => "Replace",
+                // DocumentAction::DocumentActionReplace => "Replace",
                 _ => "Unknown",
             };
             format!(

--- a/src/ui/views/strategies/operations/contract_create.rs
+++ b/src/ui/views/strategies/operations/contract_create.rs
@@ -88,6 +88,7 @@ impl FormController for StrategyOpContractCreateFormController {
             },
             keep_history_chance: rand::thread_rng().gen_range(0.01..=1.0),
             documents_mutable_chance: rand::thread_rng().gen_range(0.01..=1.0),
+            documents_can_be_deleted_chance: rand::thread_rng().gen_range(0.01..=1.0),
         };
 
         match self.input.on_event(event) {

--- a/src/ui/views/strategies/operations/contract_update_doc_types.rs
+++ b/src/ui/views/strategies/operations/contract_update_doc_types.rs
@@ -100,6 +100,7 @@ impl FormController for StrategyOpContractUpdateDocTypesFormController {
             },
             keep_history_chance: rand::thread_rng().gen_range(0.01..=1.0),
             documents_mutable_chance: rand::thread_rng().gen_range(0.01..=1.0),
+            documents_can_be_deleted_chance: rand::thread_rng().gen_range(0.01..=1.0),
         };
 
         match self.input.on_event(event) {

--- a/src/ui/views/strategies/selected_strategy.rs
+++ b/src/ui/views/strategies/selected_strategy.rs
@@ -256,7 +256,7 @@ fn display_strategy(
                             "InsertRandom".to_string()
                         }
                         DocumentAction::DocumentActionDelete => "Delete".to_string(),
-                        DocumentAction::DocumentActionReplace => "Replace".to_string(),
+                        // DocumentAction::DocumentActionReplace => "Replace".to_string(),
                         _ => panic!("invalid document action selected"),
                     };
                     format!(


### PR DESCRIPTION
- getStatus was taken out of dapi-grpc and so we use getBlockchainStatus instead now.
- updated Cargo.toml to v1.0.0-dev.12
- passed None for the new contract bounds field when registering a new identity
- added the arguments for documentsCanBeDeleted in RandomDocumentType params