### PR TITLE
fix: dont split utxos during strategy run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ explorer.drive
 
 # Logs
 explorer.log
+
+# Supporting files
+supporting_files/

--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,4 @@ explorer.drive
 explorer.log
 
 # Supporting files
-supporting_files/
+supporting_files/strategy_exports/

--- a/src/backend/strategies.rs
+++ b/src/backend/strategies.rs
@@ -1022,25 +1022,10 @@ pub async fn run_strategy_task<'s>(
                             .try_into()
                             .expect("Couldn't convert num_asset_lock_proofs_needed into usize")
                     {
-                        match wallet_lock
-                            .clone()
-                            .expect("No wallet loaded while getting asset lock proofs")
-                        {
-                            Wallet::SingleKeyWallet(mut wallet) => {
-                                if let Err(e) = wallet
-                                    .split_utxos(
-                                        sdk,
-                                        num_asset_lock_proofs_needed.try_into().unwrap(),
-                                    )
-                                    .await
-                                {
-                                    tracing::error!(
-                                        "Error splitting utxos for asset lock proofs: {}",
-                                        e
-                                    );
-                                };
-                            }
-                        }
+                        return BackendEvent::StrategyError {
+                            strategy_name: strategy_name.clone(),
+                            error: format!("Not enough UTXOs available in wallet. Available: {}. Need: {}. Go to Wallet screen and create more.", num_available_utxos, num_asset_lock_proofs_needed),
+                        };
                     }
                     tracing::info!(
                         "Obtaining {} asset lock proofs for the strategy...",


### PR DESCRIPTION
The issue was that when a user tried to split utxos during a strategy run and then use them for asset lock proofs, for some reason, it would give a tx-txlock-conflict error. Probably something with the state not being updated properly after splitting utxos. To solve it, I just returned an error if a user doesn’t have enough utxos in their wallet, and prompt them to go to the Wallet screen and create more. If they create utxos in the wallet screen and then try to run the strategy, for some reason, that works. Someday I could spend more time on getting it to work on strategy run if it becomes important.