### PR TITLE
feat(strategy-tests): limit identities to 24 documents per contract in the mempool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,7 +998,7 @@ dependencies = [
 [[package]]
 name = "dapi-grpc"
 version = "1.0.0-beta.4"
-source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
+source = "git+https://github.com/dashpay/platform?rev=9a177ff8fbe26830e053bbf252d153c3a81e39bb#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "dapi-grpc-macros",
  "futures-core",
@@ -1015,7 +1015,7 @@ dependencies = [
 [[package]]
 name = "dapi-grpc-macros"
 version = "1.0.0-beta.4"
-source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
+source = "git+https://github.com/dashpay/platform?rev=9a177ff8fbe26830e053bbf252d153c3a81e39bb#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "heck 0.5.0",
  "quote",
@@ -1060,7 +1060,7 @@ dependencies = [
 [[package]]
 name = "dash-sdk"
 version = "1.0.0-beta.4"
-source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
+source = "git+https://github.com/dashpay/platform?rev=9a177ff8fbe26830e053bbf252d153c3a81e39bb#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1166,7 +1166,7 @@ dependencies = [
 [[package]]
 name = "dashpay-contract"
 version = "1.0.0-beta.4"
-source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
+source = "git+https://github.com/dashpay/platform?rev=9a177ff8fbe26830e053bbf252d153c3a81e39bb#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -1177,7 +1177,7 @@ dependencies = [
 [[package]]
 name = "data-contracts"
 version = "1.0.0-beta.4"
-source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
+source = "git+https://github.com/dashpay/platform?rev=9a177ff8fbe26830e053bbf252d153c3a81e39bb#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "dashpay-contract",
  "dpns-contract",
@@ -1259,7 +1259,7 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 [[package]]
 name = "dpns-contract"
 version = "1.0.0-beta.4"
-source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
+source = "git+https://github.com/dashpay/platform?rev=9a177ff8fbe26830e053bbf252d153c3a81e39bb#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -1270,7 +1270,7 @@ dependencies = [
 [[package]]
 name = "dpp"
 version = "1.0.0-beta.4"
-source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
+source = "git+https://github.com/dashpay/platform?rev=9a177ff8fbe26830e053bbf252d153c3a81e39bb#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1318,7 +1318,7 @@ dependencies = [
 [[package]]
 name = "drive"
 version = "1.0.0-beta.4"
-source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
+source = "git+https://github.com/dashpay/platform?rev=9a177ff8fbe26830e053bbf252d153c3a81e39bb#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "arc-swap",
  "base64 0.22.1",
@@ -1355,7 +1355,7 @@ dependencies = [
 [[package]]
 name = "drive-proof-verifier"
 version = "1.0.0-beta.4"
-source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
+source = "git+https://github.com/dashpay/platform?rev=9a177ff8fbe26830e053bbf252d153c3a81e39bb#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "bincode",
  "dapi-grpc",
@@ -1580,7 +1580,7 @@ checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 [[package]]
 name = "feature-flags-contract"
 version = "1.0.0-beta.4"
-source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
+source = "git+https://github.com/dashpay/platform?rev=9a177ff8fbe26830e053bbf252d153c3a81e39bb#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2458,7 +2458,7 @@ dependencies = [
 [[package]]
 name = "json-schema-compatibility-validator"
 version = "1.0.0-beta.4"
-source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
+source = "git+https://github.com/dashpay/platform?rev=9a177ff8fbe26830e053bbf252d153c3a81e39bb#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "json-patch",
  "once_cell",
@@ -2665,7 +2665,7 @@ dependencies = [
 [[package]]
 name = "masternode-reward-shares-contract"
 version = "1.0.0-beta.4"
-source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
+source = "git+https://github.com/dashpay/platform?rev=9a177ff8fbe26830e053bbf252d153c3a81e39bb#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -3205,7 +3205,7 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 [[package]]
 name = "platform-serialization"
 version = "1.0.0-beta.4"
-source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
+source = "git+https://github.com/dashpay/platform?rev=9a177ff8fbe26830e053bbf252d153c3a81e39bb#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "bincode",
  "platform-version",
@@ -3214,7 +3214,7 @@ dependencies = [
 [[package]]
 name = "platform-serialization-derive"
 version = "1.0.0-beta.4"
-source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
+source = "git+https://github.com/dashpay/platform?rev=9a177ff8fbe26830e053bbf252d153c3a81e39bb#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3225,7 +3225,7 @@ dependencies = [
 [[package]]
 name = "platform-value"
 version = "1.0.0-beta.4"
-source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
+source = "git+https://github.com/dashpay/platform?rev=9a177ff8fbe26830e053bbf252d153c3a81e39bb#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -3247,7 +3247,7 @@ dependencies = [
 [[package]]
 name = "platform-version"
 version = "1.0.0-beta.4"
-source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
+source = "git+https://github.com/dashpay/platform?rev=9a177ff8fbe26830e053bbf252d153c3a81e39bb#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "bincode",
  "grovedb-version",
@@ -3259,7 +3259,7 @@ dependencies = [
 [[package]]
 name = "platform-versioning"
 version = "1.0.0-beta.4"
-source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
+source = "git+https://github.com/dashpay/platform?rev=9a177ff8fbe26830e053bbf252d153c3a81e39bb#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3798,7 +3798,7 @@ dependencies = [
 [[package]]
 name = "rs-dapi-client"
 version = "1.0.0-beta.4"
-source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
+source = "git+https://github.com/dashpay/platform?rev=9a177ff8fbe26830e053bbf252d153c3a81e39bb#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "backon",
  "chrono",
@@ -4292,7 +4292,7 @@ checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 [[package]]
 name = "simple-signer"
 version = "1.0.0-beta.4"
-source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
+source = "git+https://github.com/dashpay/platform?rev=9a177ff8fbe26830e053bbf252d153c3a81e39bb#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -4415,7 +4415,7 @@ checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 [[package]]
 name = "strategy-tests"
 version = "1.0.0-beta.4"
-source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
+source = "git+https://github.com/dashpay/platform?rev=9a177ff8fbe26830e053bbf252d153c3a81e39bb#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "bincode",
  "dpp",
@@ -5705,7 +5705,7 @@ dependencies = [
 [[package]]
 name = "withdrawals-contract"
 version = "1.0.0-beta.4"
-source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
+source = "git+https://github.com/dashpay/platform?rev=9a177ff8fbe26830e053bbf252d153c3a81e39bb#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "num_enum",
  "platform-value",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,8 +997,8 @@ dependencies = [
 
 [[package]]
 name = "dapi-grpc"
-version = "1.0.0-beta.3"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-beta.3#bf84d9de60f55790795cfaf5dc1e3f7c467eae22"
+version = "1.0.0-beta.4"
+source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "dapi-grpc-macros",
  "futures-core",
@@ -1014,8 +1014,8 @@ dependencies = [
 
 [[package]]
 name = "dapi-grpc-macros"
-version = "1.0.0-beta.3"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-beta.3#bf84d9de60f55790795cfaf5dc1e3f7c467eae22"
+version = "1.0.0-beta.4"
+source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "heck 0.5.0",
  "quote",
@@ -1059,8 +1059,8 @@ dependencies = [
 
 [[package]]
 name = "dash-sdk"
-version = "1.0.0-beta.3"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-beta.3#bf84d9de60f55790795cfaf5dc1e3f7c467eae22"
+version = "1.0.0-beta.4"
+source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1165,8 +1165,8 @@ dependencies = [
 
 [[package]]
 name = "dashpay-contract"
-version = "1.0.0-beta.3"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-beta.3#bf84d9de60f55790795cfaf5dc1e3f7c467eae22"
+version = "1.0.0-beta.4"
+source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -1176,8 +1176,8 @@ dependencies = [
 
 [[package]]
 name = "data-contracts"
-version = "1.0.0-beta.3"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-beta.3#bf84d9de60f55790795cfaf5dc1e3f7c467eae22"
+version = "1.0.0-beta.4"
+source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "dashpay-contract",
  "dpns-contract",
@@ -1258,8 +1258,8 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpns-contract"
-version = "1.0.0-beta.3"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-beta.3#bf84d9de60f55790795cfaf5dc1e3f7c467eae22"
+version = "1.0.0-beta.4"
+source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -1269,8 +1269,8 @@ dependencies = [
 
 [[package]]
 name = "dpp"
-version = "1.0.0-beta.3"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-beta.3#bf84d9de60f55790795cfaf5dc1e3f7c467eae22"
+version = "1.0.0-beta.4"
+source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1317,8 +1317,8 @@ dependencies = [
 
 [[package]]
 name = "drive"
-version = "1.0.0-beta.3"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-beta.3#bf84d9de60f55790795cfaf5dc1e3f7c467eae22"
+version = "1.0.0-beta.4"
+source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "arc-swap",
  "base64 0.22.1",
@@ -1354,8 +1354,8 @@ dependencies = [
 
 [[package]]
 name = "drive-proof-verifier"
-version = "1.0.0-beta.3"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-beta.3#bf84d9de60f55790795cfaf5dc1e3f7c467eae22"
+version = "1.0.0-beta.4"
+source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "bincode",
  "dapi-grpc",
@@ -1579,8 +1579,8 @@ checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "feature-flags-contract"
-version = "1.0.0-beta.3"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-beta.3#bf84d9de60f55790795cfaf5dc1e3f7c467eae22"
+version = "1.0.0-beta.4"
+source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2457,8 +2457,8 @@ dependencies = [
 
 [[package]]
 name = "json-schema-compatibility-validator"
-version = "1.0.0-beta.3"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-beta.3#bf84d9de60f55790795cfaf5dc1e3f7c467eae22"
+version = "1.0.0-beta.4"
+source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "json-patch",
  "once_cell",
@@ -2664,8 +2664,8 @@ dependencies = [
 
 [[package]]
 name = "masternode-reward-shares-contract"
-version = "1.0.0-beta.3"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-beta.3#bf84d9de60f55790795cfaf5dc1e3f7c467eae22"
+version = "1.0.0-beta.4"
+source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -3204,8 +3204,8 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "platform-serialization"
-version = "1.0.0-beta.3"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-beta.3#bf84d9de60f55790795cfaf5dc1e3f7c467eae22"
+version = "1.0.0-beta.4"
+source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "bincode",
  "platform-version",
@@ -3213,8 +3213,8 @@ dependencies = [
 
 [[package]]
 name = "platform-serialization-derive"
-version = "1.0.0-beta.3"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-beta.3#bf84d9de60f55790795cfaf5dc1e3f7c467eae22"
+version = "1.0.0-beta.4"
+source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3224,8 +3224,8 @@ dependencies = [
 
 [[package]]
 name = "platform-value"
-version = "1.0.0-beta.3"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-beta.3#bf84d9de60f55790795cfaf5dc1e3f7c467eae22"
+version = "1.0.0-beta.4"
+source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -3246,8 +3246,8 @@ dependencies = [
 
 [[package]]
 name = "platform-version"
-version = "1.0.0-beta.3"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-beta.3#bf84d9de60f55790795cfaf5dc1e3f7c467eae22"
+version = "1.0.0-beta.4"
+source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "bincode",
  "grovedb-version",
@@ -3258,8 +3258,8 @@ dependencies = [
 
 [[package]]
 name = "platform-versioning"
-version = "1.0.0-beta.3"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-beta.3#bf84d9de60f55790795cfaf5dc1e3f7c467eae22"
+version = "1.0.0-beta.4"
+source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3797,8 +3797,8 @@ dependencies = [
 
 [[package]]
 name = "rs-dapi-client"
-version = "1.0.0-beta.3"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-beta.3#bf84d9de60f55790795cfaf5dc1e3f7c467eae22"
+version = "1.0.0-beta.4"
+source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "backon",
  "chrono",
@@ -4291,8 +4291,8 @@ checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "simple-signer"
-version = "1.0.0-beta.3"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-beta.3#bf84d9de60f55790795cfaf5dc1e3f7c467eae22"
+version = "1.0.0-beta.4"
+source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -4414,8 +4414,8 @@ checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
 name = "strategy-tests"
-version = "1.0.0-beta.3"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-beta.3#bf84d9de60f55790795cfaf5dc1e3f7c467eae22"
+version = "1.0.0-beta.4"
+source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "bincode",
  "dpp",
@@ -5704,8 +5704,8 @@ dependencies = [
 
 [[package]]
 name = "withdrawals-contract"
-version = "1.0.0-beta.3"
-source = "git+https://github.com/dashpay/platform?tag=v1.0.0-beta.3#bf84d9de60f55790795cfaf5dc1e3f7c467eae22"
+version = "1.0.0-beta.4"
+source = "git+https://github.com/dashpay/platform?branch=v1.0-dev#9a177ff8fbe26830e053bbf252d153c3a81e39bb"
 dependencies = [
  "num_enum",
  "platform-value",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,24 +10,24 @@ strum = { version = "0.26.1", features = ["derive"] }
 tui-realm-stdlib = "1.3.1"
 tuirealm = "1.9.1"
 bs58 = "0.5.0"
-dpp = { git = "https://github.com/dashpay/platform", tag = "v1.0.0-beta.3", features = [
+dpp = { git = "https://github.com/dashpay/platform", branch = "v1.0-dev", features = [
     "client",
 ] }
-dash-sdk = { git = "https://github.com/dashpay/platform", tag = "v1.0.0-beta.3" }
-drive = { git = "https://github.com/dashpay/platform", tag = "v1.0.0-beta.3" }
-drive-proof-verifier = { git = "https://github.com/dashpay/platform", tag = "v1.0.0-beta.3" }
+dash-sdk = { git = "https://github.com/dashpay/platform", branch = "v1.0-dev" }
+drive = { git = "https://github.com/dashpay/platform", branch = "v1.0-dev" }
+drive-proof-verifier = { git = "https://github.com/dashpay/platform", branch = "v1.0-dev" }
 thiserror = "1"
 serde = "1.0.197"
 serde_json = "1.0.120"
 toml = { version = "0.8.10", features = ["display"] }
-dapi-grpc = { git = "https://github.com/dashpay/platform", tag = "v1.0.0-beta.3", features = [
+dapi-grpc = { git = "https://github.com/dashpay/platform", branch = "v1.0-dev", features = [
     "client",
 ] }
-rs-dapi-client = { git = "https://github.com/dashpay/platform", tag = "v1.0.0-beta.3" }
+rs-dapi-client = { git = "https://github.com/dashpay/platform", branch = "v1.0-dev" }
 tokio = { version = "1.36.0", features = ["full"] }
 bincode = { version = "2.0.0-rc.3", features = ["serde"] }
-strategy-tests = { git = "https://github.com/dashpay/platform", tag = "v1.0.0-beta.3" }
-simple-signer = { git = "https://github.com/dashpay/platform", tag = "v1.0.0-beta.3" }
+strategy-tests = { git = "https://github.com/dashpay/platform", branch = "v1.0-dev" }
+simple-signer = { git = "https://github.com/dashpay/platform", branch = "v1.0-dev" }
 reqwest = { version = "0.12.3", features = ["json"] }
 hex = { version = "0.4.3" }
 itertools = "0.12.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,24 +10,24 @@ strum = { version = "0.26.1", features = ["derive"] }
 tui-realm-stdlib = "1.3.1"
 tuirealm = "1.9.1"
 bs58 = "0.5.0"
-dpp = { git = "https://github.com/dashpay/platform", branch = "v1.0-dev", features = [
+dpp = { git = "https://github.com/dashpay/platform", rev = "9a177ff8fbe26830e053bbf252d153c3a81e39bb", features = [
     "client",
 ] }
-dash-sdk = { git = "https://github.com/dashpay/platform", branch = "v1.0-dev" }
-drive = { git = "https://github.com/dashpay/platform", branch = "v1.0-dev" }
-drive-proof-verifier = { git = "https://github.com/dashpay/platform", branch = "v1.0-dev" }
+dash-sdk = { git = "https://github.com/dashpay/platform", rev = "9a177ff8fbe26830e053bbf252d153c3a81e39bb" }
+drive = { git = "https://github.com/dashpay/platform", rev = "9a177ff8fbe26830e053bbf252d153c3a81e39bb" }
+drive-proof-verifier = { git = "https://github.com/dashpay/platform", rev = "9a177ff8fbe26830e053bbf252d153c3a81e39bb" }
 thiserror = "1"
 serde = "1.0.197"
 serde_json = "1.0.120"
 toml = { version = "0.8.10", features = ["display"] }
-dapi-grpc = { git = "https://github.com/dashpay/platform", branch = "v1.0-dev", features = [
+dapi-grpc = { git = "https://github.com/dashpay/platform", rev = "9a177ff8fbe26830e053bbf252d153c3a81e39bb", features = [
     "client",
 ] }
-rs-dapi-client = { git = "https://github.com/dashpay/platform", branch = "v1.0-dev" }
+rs-dapi-client = { git = "https://github.com/dashpay/platform", rev = "9a177ff8fbe26830e053bbf252d153c3a81e39bb" }
 tokio = { version = "1.36.0", features = ["full"] }
 bincode = { version = "2.0.0-rc.3", features = ["serde"] }
-strategy-tests = { git = "https://github.com/dashpay/platform", branch = "v1.0-dev" }
-simple-signer = { git = "https://github.com/dashpay/platform", branch = "v1.0-dev" }
+strategy-tests = { git = "https://github.com/dashpay/platform", rev = "9a177ff8fbe26830e053bbf252d153c3a81e39bb" }
+simple-signer = { git = "https://github.com/dashpay/platform", rev = "9a177ff8fbe26830e053bbf252d153c3a81e39bb" }
 reqwest = { version = "0.12.3", features = ["json"] }
 hex = { version = "0.4.3" }
 itertools = "0.12.1"

--- a/src/backend/strategies.rs
+++ b/src/backend/strategies.rs
@@ -117,6 +117,8 @@ pub enum StrategyTask {
     RemoveLastOperation(String),
 }
 
+pub type MempoolDocumentCounter = BTreeMap<(Identifier, Identifier), u64>; // maps (identity id, contract id) to documents_count
+
 pub async fn run_strategy_task<'s>(
     sdk: &Sdk,
     app_state: &'s AppState,
@@ -1089,7 +1091,7 @@ pub async fn run_strategy_task<'s>(
                 let mut new_contract_ids = Vec::new(); // Will capture the ids of newly created data contracts
                 let oks = Arc::new(AtomicU32::new(0)); // Atomic counter for successful broadcasts
                 let errs = Arc::new(AtomicU32::new(0)); // Atomic counter for failed broadcasts
-                let mempool_document_counter = Arc::new(Mutex::new(BTreeMap::<(Identifier, Identifier), u64>::new())); // Map to track how many documents an identity has in the mempool per contract
+                let mempool_document_counter = Arc::new(Mutex::new(MempoolDocumentCounter::new())); // Map to track how many documents an identity has in the mempool per contract
 
                 // Now loop through the number of blocks or seconds the user asked for, preparing and processing state transitions
                 while (block_mode && current_block_info.height < (initial_block_info.height + num_blocks_or_seconds + 2)) // +2 because we don't count the first two initialization blocks

--- a/src/backend/strategies.rs
+++ b/src/backend/strategies.rs
@@ -1370,7 +1370,7 @@ pub async fn run_strategy_task<'s>(
                                                     // But it is necessary. `rs-dapi-client` does not log all the errors already. For example, IdentityNotFound errors
                                                     // Update: rs-dapi-client logs have been turned off
                                                     tracing::error!("Error: Failed to broadcast {} transition: {:?}. ID: {}", transition_clone.name(), e, transition_id);
-                                                    if e.to_string().contains("Insufficient identity balance") {
+                                                    if e.to_string().contains("Insufficient identity") {
                                                         let mut current_identities = current_identities_clone.lock().await;
                                                         current_identities.retain(|identity| identity.id() != transition_clone.owner_id());
                                                     }

--- a/src/backend/strategies.rs
+++ b/src/backend/strategies.rs
@@ -1378,48 +1378,48 @@ pub async fn run_strategy_task<'s>(
                                                     tracing::error!("Error: Failed to broadcast {} transition: {:?}. ID: {}", transition_clone.name(), e, transition_id);
                                                     if e.to_string().contains("Insufficient identity") {
                                                         insufficient_balance_error_count += 1;
-                                                        let mut wallet_lock = app_state.loaded_wallet.lock().await;
+                                                        // let mut wallet_lock = app_state.loaded_wallet.lock().await;
                                                         let mut current_identities = current_identities_clone.lock().await;
-                                                        if top_up_amount > 0 {
-                                                            // Top up
-                                                            if let Some(wallet) = wallet_lock.as_mut() {
-                                                                match wallet.asset_lock_transaction(
-                                                                    None,
-                                                                    top_up_amount,
-                                                                ) {
-                                                                    Ok((asset_lock_transaction, asset_lock_proof_private_key)) => {
-                                                                        match try_broadcast_and_retrieve_asset_lock(sdk, &asset_lock_transaction, &wallet.receive_address(), 2).await {
-                                                                            Ok(asset_lock_proof) => {
-                                                                                tracing::info!("Successfully obtained asset lock proof for top up");
-                                                                                let identity = current_identities.iter_mut().find(|identity| identity.id() == transition_clone.owner_id()).expect("Expected to find identity ID matching transition owner ID");
-                                                                                match identity.top_up_identity(
-                                                                                    sdk,
-                                                                                    asset_lock_proof,
-                                                                                    &asset_lock_proof_private_key,
-                                                                                    None,
-                                                                                ).await {
-                                                                                    Ok(balance) => tracing::info!("Topped up identity {}. New balance: {}", identity.id().to_string(Encoding::Base58), balance),
-                                                                                    Err(e) => tracing::error!("Failed to top up identity {}: {}", identity.id().to_string(Encoding::Base58), e)
-                                                                                }
-                                                                            }
-                                                                            Err(_) => {
-                                                                                tracing::error!("Failed to obtain asset lock proof for top up");
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                    Err(e) => {
-                                                                        tracing::error!(
-                                                                            "Error creating asset lock transaction: {:?}",
-                                                                            e
-                                                                        )
-                                                                    }
-                                                                }
-                                                            } else {
-                                                                tracing::error!("Wallet not loaded");
-                                                            }
-                                                        } else {
+                                                        // if top_up_amount > 0 {
+                                                        //     // Top up
+                                                        //     if let Some(wallet) = wallet_lock.as_mut() {
+                                                        //         match wallet.asset_lock_transaction(
+                                                        //             None,
+                                                        //             top_up_amount,
+                                                        //         ) {
+                                                        //             Ok((asset_lock_transaction, asset_lock_proof_private_key)) => {
+                                                        //                 match try_broadcast_and_retrieve_asset_lock(sdk, &asset_lock_transaction, &wallet.receive_address(), 2).await {
+                                                        //                     Ok(asset_lock_proof) => {
+                                                        //                         tracing::info!("Successfully obtained asset lock proof for top up");
+                                                        //                         let identity = current_identities.iter_mut().find(|identity| identity.id() == transition_clone.owner_id()).expect("Expected to find identity ID matching transition owner ID");
+                                                        //                         match identity.top_up_identity(
+                                                        //                             sdk,
+                                                        //                             asset_lock_proof,
+                                                        //                             &asset_lock_proof_private_key,
+                                                        //                             None,
+                                                        //                         ).await {
+                                                        //                             Ok(balance) => tracing::info!("Topped up identity {}. New balance: {}", identity.id().to_string(Encoding::Base58), balance),
+                                                        //                             Err(e) => tracing::error!("Failed to top up identity {}: {}", identity.id().to_string(Encoding::Base58), e)
+                                                        //                         }
+                                                        //                     }
+                                                        //                     Err(_) => {
+                                                        //                         tracing::error!("Failed to obtain asset lock proof for top up");
+                                                        //                     }
+                                                        //                 }
+                                                        //             }
+                                                        //             Err(e) => {
+                                                        //                 tracing::error!(
+                                                        //                     "Error creating asset lock transaction: {:?}",
+                                                        //                     e
+                                                        //                 )
+                                                        //             }
+                                                        //         }
+                                                        //     } else {
+                                                        //         tracing::error!("Wallet not loaded");
+                                                        //     }
+                                                        // } else {
                                                             current_identities.retain(|identity| identity.id() != transition_clone.owner_id());    
-                                                        }
+                                                        // }
                                                     } else if e.to_string().contains("invalid identity nonce") {
                                                         identity_nonce_error_count += 1;
                                                     } else if e.to_string().contains("") {
@@ -1967,7 +1967,8 @@ pub async fn run_strategy_task<'s>(
                     tracing::info!(
                         "-----Strategy '{}' completed-----\n\nMode: {}\nState transitions attempted: {}\nState \
                         transitions succeeded: {}\nNumber of loops: {}\nLoad run time: \
-                        {:?} seconds\nInit run time: {} seconds\nAttempted rate (approx): {} txs/s\nSuccessful rate: {} tx/s\nSuccess percentage: {}%\nDash spent (Loaded Identity): {}\nDash spent (Wallet): {}\n",
+                        {:?} seconds\nInit run time: {} seconds\nAttempted rate (approx): {} txs/s\nSuccessful rate: {} tx/s\nSuccess percentage: {}%\nDash spent (Loaded Identity): {}\nDash spent (Wallet): {}\nNonce \
+                        errors: {}\nBalance errors: {}\nRate limit errors: {}\nBroadcast timeout errors: {}",
                         strategy_name,
                         mode_string,
                         transition_count,
@@ -1980,6 +1981,10 @@ pub async fn run_strategy_task<'s>(
                         success_percent,
                         dash_spent_identity,
                         dash_spent_wallet,
+                        identity_nonce_error_count,
+                        insufficient_balance_error_count,
+                        local_rate_limit_error_count,
+                        broadcast_timeout_error_count
                     );
                 }
 

--- a/src/backend/strategies.rs
+++ b/src/backend/strategies.rs
@@ -1117,7 +1117,7 @@ pub async fn run_strategy_task<'s>(
                             &mut signer,
                             &mut identity_nonce_counter,
                             &mut contract_nonce_counter,
-                            mempool_document_counter_lock.clone(),
+                            &mempool_document_counter_lock,
                             &mut rng,
                             &StrategyConfig {
                                 start_block_height: initial_block_info.height,

--- a/src/backend/strategies.rs
+++ b/src/backend/strategies.rs
@@ -117,8 +117,6 @@ pub enum StrategyTask {
     RemoveLastOperation(String),
 }
 
-pub type MempoolDocumentCounter = BTreeMap<(Identifier, Identifier), u64>; // maps (identity id, contract id) to documents_count
-
 pub async fn run_strategy_task<'s>(
     sdk: &Sdk,
     app_state: &'s AppState,
@@ -1091,7 +1089,7 @@ pub async fn run_strategy_task<'s>(
                 let mut new_contract_ids = Vec::new(); // Will capture the ids of newly created data contracts
                 let oks = Arc::new(AtomicU32::new(0)); // Atomic counter for successful broadcasts
                 let errs = Arc::new(AtomicU32::new(0)); // Atomic counter for failed broadcasts
-                let mempool_document_counter = Arc::new(Mutex::new(MempoolDocumentCounter::new())); // Map to track how many documents an identity has in the mempool per contract
+                let mempool_document_counter = Arc::new(Mutex::new(BTreeMap::<(Identifier, Identifier), u64>::new())); // Map to track how many documents an identity has in the mempool per contract
 
                 // Now loop through the number of blocks or seconds the user asked for, preparing and processing state transitions
                 while (block_mode && current_block_info.height < (initial_block_info.height + num_blocks_or_seconds + 2)) // +2 because we don't count the first two initialization blocks

--- a/src/backend/strategies.rs
+++ b/src/backend/strategies.rs
@@ -1310,6 +1310,7 @@ pub async fn run_strategy_task<'s>(
                                     );
                                 }
                             } else {
+                                // Independent state transitions
                                 let oks = oks_clone.clone();
                                 let errs = errs_clone.clone();
 
@@ -1335,6 +1336,7 @@ pub async fn run_strategy_task<'s>(
                                             match broadcast_result {
                                                 Ok(_) => {
                                                     oks.fetch_add(1, Ordering::SeqCst);
+                                                    success_count += 1;
                                                     let transition_owner_id = transition_clone.owner_id().to_string(Encoding::Base58);
                                                     if !block_mode && index != 1 && index != 2 {
                                                         tracing::info!("Successfully broadcasted transition: {}. ID: {}. Owner ID: {:?}", transition_clone.name(), transition_id, transition_owner_id);
@@ -1577,16 +1579,6 @@ pub async fn run_strategy_task<'s>(
 
                             // Wait for all state transition result futures to complete
                             let wait_results = join_all(wait_futures).await;
-
-                            // Log the actual block height for each state transition
-                            for (_, actual_block_height) in wait_results.into_iter().enumerate() {
-                                match actual_block_height {
-                                    Some(_) => {
-                                        success_count += 1;
-                                    }
-                                    None => continue,
-                                }
-                            }
                         } else {
                             // Time mode when index is greater than 2
                             let request_settings = RequestSettings {

--- a/src/backend/strategies.rs
+++ b/src/backend/strategies.rs
@@ -1121,6 +1121,7 @@ pub async fn run_strategy_task<'s>(
                             &mut signer,
                             &mut identity_nonce_counter,
                             &mut contract_nonce_counter,
+                            mempool_document_counter_lock.clone(),
                             &mut rng,
                             &StrategyConfig {
                                 start_block_height: initial_block_info.height,

--- a/src/backend/strategies.rs
+++ b/src/backend/strategies.rs
@@ -1,7 +1,7 @@
 //! Strategies management backend module.
 
 use std::{
-    collections::{BTreeMap, BTreeSet, VecDeque},
+    collections::{BTreeMap, BTreeSet, HashMap, VecDeque},
     fs::File,
     io::Write,
     sync::{
@@ -1102,14 +1102,44 @@ pub async fn run_strategy_task<'s>(
                 let mut new_contract_ids = Vec::new(); // Will capture the ids of newly created data contracts
                 let oks = Arc::new(AtomicUsize::new(0)); // Atomic counter for successful broadcasts
                 let errs = Arc::new(AtomicUsize::new(0)); // Atomic counter for failed broadcasts
+                let transitions_counter = Arc::new(Mutex::new(HashMap::<String, usize>::new())); // Hashmap to track how many transitions an identity is waiting for results for
 
                 // Now loop through the number of blocks or seconds the user asked for, preparing and processing state transitions
                 while (block_mode && current_block_info.height < (initial_block_info.height + num_blocks_or_seconds + 2)) // +2 because we don't count the first two initialization blocks
                     || (!block_mode && load_start_time.elapsed().as_secs() < num_blocks_or_seconds) || index <= 2
                 {
+                    let loop_start_time = Instant::now();
                     let oks_clone = oks.clone();
                     let errs_clone = errs.clone();
-                    let loop_start_time = Instant::now();
+
+                    // In time mode, filter identities that have fewer than 24 transitions
+                    let mut eligible_identities = Vec::new();
+                    if !block_mode {
+                        let mut transitions_counter_lock = transitions_counter.lock().await;
+                        for identity in &current_identities {
+                            let count = transitions_counter_lock
+                                .entry(identity.id().to_string(Encoding::Base58))
+                                .or_insert(0);
+                            if *count < 24 {
+                                eligible_identities.push(identity.clone());
+                            }
+                        }
+                    } else {
+                        eligible_identities = current_identities.clone();
+                    }
+
+                    tracing::info!("Eligible identities: {}", eligible_identities.len());
+                    if eligible_identities.is_empty() {
+                        return BackendEvent::StrategyCompleted {
+                            strategy_name,
+                            result: StrategyCompletionResult::PartiallyCompleted {
+                                reached_block_height: index,
+                                reason: format!(
+                                    "Ran out of identities for submitting state transitions"
+                                ),
+                            },
+                        };
+                    }
 
                     // Need to pass app_state.known_contracts to state_transitions_for_block
                     let mut known_contracts_lock = app_state.known_contracts.lock().await;
@@ -1121,7 +1151,7 @@ pub async fn run_strategy_task<'s>(
                             &mut identity_fetch_callback,
                             &mut asset_lock_proofs,
                             &current_block_info,
-                            &mut current_identities,
+                            &mut eligible_identities,
                             &mut known_contracts_lock,
                             &mut signer,
                             &mut identity_nonce_counter,
@@ -1209,6 +1239,7 @@ pub async fn run_strategy_task<'s>(
                             st_queue_index += 1; // Start at 1 and iterate upwards since we're only using this for logs
                             let transition_clone = transition.clone();
                             let transition_type = transition_clone.name().to_owned();
+                            let transitions_counter_clone = transitions_counter.clone();
 
                             // Determine if the transitions is a dependent transition.
                             // Dependent state transitions are those that get their revision checked. Sending multiple
@@ -1334,6 +1365,10 @@ pub async fn run_strategy_task<'s>(
                                                     if !block_mode && index != 1 && index != 2 {
                                                         tracing::info!("Successfully broadcasted transition: {}", transition_clone.name());
                                                     }
+                                                    let identity_id = transition_clone.owner_id().to_string(Encoding::Base58);
+                                                    let mut transitions_counter_clone_lock = transitions_counter_clone.lock().await;
+                                                    let count = transitions_counter_clone_lock.entry(identity_id).or_insert(0);
+                                                    *count += 1;
                                                     Ok((transition_clone, broadcast_result))
                                                 },
                                                 Err(e) => {
@@ -1559,13 +1594,63 @@ pub async fn run_strategy_task<'s>(
                                 }
                             }
                         } else {
-                            // Time mode.
-                            // Don't wait.
+                            // Time mode when index is greater than 2
+                            let sdk_clone = sdk.clone();
+                            for (index, result) in broadcast_results.into_iter().enumerate() {
+                                let transitions_counter_clone = transitions_counter.clone();
+                                match result {
+                                    Ok((transition, _broadcast_result)) => {
+                                        let transition_type = transition.name().to_owned();
+                                        let sdk_clone_inner = sdk_clone.clone();
+
+                                        tokio::spawn(async move {
+                                            if let Ok(wait_request) = transition
+                                                .wait_for_state_transition_result_request()
+                                            {
+                                                match wait_request
+                                                    .execute(
+                                                        &sdk_clone_inner,
+                                                        RequestSettings::default(),
+                                                    )
+                                                    .await
+                                                {
+                                                    Ok(wait_response) => {
+                                                        if let Some(wait_for_state_transition_result_response::Version::V0(v0_response)) = &wait_response.version {
+                                                            if let Some(wait_for_state_transition_result_response_v0::Result::Proof(_proof)) = &v0_response.result {
+                                                                // Assume the proof is correct in time mode for now
+                                                                let identity_id = transition.owner_id().to_string(Encoding::Base58);
+                                                                let mut transitions_counter_lock = transitions_counter_clone.lock().await;
+                                                                if let Some(count) = transitions_counter_lock.get_mut(&identity_id) {
+                                                                    *count -= 1; // Decrement the transition count on successful verification
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                    Err(e) => {
+                                                        tracing::error!("Error waiting for state transition result: {:?}, for transition {}: {}", e, index + 1, transition_type);
+                                                    }
+                                                }
+                                            } else {
+                                                tracing::error!("Failed to create wait request for state transition {}: {}", index + 1, transition_type);
+                                            }
+                                        });
+                                    }
+                                    Err(e) => {
+                                        tracing::error!(
+                                            "Error broadcasting state transition {}: {:?}",
+                                            index + 1,
+                                            e,
+                                        );
+                                    }
+                                }
+                            }
                         }
 
                         // Reset the load_start_time
+                        // Also, sleep 10 seconds to let nodes update state
                         if index == 1 || index == 2 {
                             load_start_time = Instant::now();
+                            tokio::time::sleep(Duration::from_secs(10)).await;
                         }
                     } else {
                         // No transitions prepared for the block (or second)

--- a/src/bin/strategy.rs
+++ b/src/bin/strategy.rs
@@ -35,6 +35,13 @@ struct Args {
     blocks: u64,
 
     #[arg(
+        long,
+        default_value_t = 0.0,
+        help = "Specifies the amount to top up identities who run out of credits. Default 0."
+    )]
+    top_up_amount: f64,
+
+    #[arg(
         short,
         long,
         help = "Specifies the minimum amount of Dash the loaded identity should have."
@@ -209,6 +216,9 @@ async fn main() {
             }
         }
     }
+
+    let credit_amount = (args.top_up_amount * 100_000_000_000.0) as u64;
+
     if let Some(test_name) = args.test {
         let block_mode = if args.time_mode { false } else { true };
         backend::strategies::run_strategy_task(
@@ -219,6 +229,7 @@ async fn main() {
                 args.blocks,
                 args.prove,
                 block_mode,
+                credit_amount,
             ),
             &insight,
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,14 +10,19 @@ use rs_platform_explorer::{
     ui::{IdentityBalance, Ui, UiFeedback},
     Event,
 };
+use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
 async fn main() {
     // Initialize logger
     let log_file = File::create("explorer.log").expect("create log file");
 
+    let filter = EnvFilter::try_new("info")
+        .unwrap()
+        .add_directive("rs_dapi_client=off".parse().unwrap()); // Turn off all logs from `rs-dapi-client`
+
     let subscriber = tracing_subscriber::fmt()
-        .with_env_filter("info")
+        .with_env_filter(filter)
         .with_writer(log_file)
         .with_ansi(false)
         .finish();

--- a/src/ui/views/strategies/run_strategy.rs
+++ b/src/ui/views/strategies/run_strategy.rs
@@ -135,8 +135,8 @@ impl ScreenController for RunStrategyScreenController {
                         reason,
                     } => {
                         format!(
-                            "Strategy '{}' failed to complete. Reached block height {}. Reason: {}",
-                            strategy_name, reached_block_height, reason
+                            "Strategy '{}' failed to complete. Reason: {}",
+                            strategy_name, reason
                         )
                     }
                 };

--- a/src/ui/views/strategies/run_strategy.rs
+++ b/src/ui/views/strategies/run_strategy.rs
@@ -19,8 +19,6 @@ use crate::{
     Event,
 };
 
-use super::selected_strategy::SelectedStrategyScreenController;
-
 const COMMAND_KEYS: [ScreenCommandKey; 2] = [
     ScreenCommandKey::new("q", "Back to Strategy"),
     ScreenCommandKey::new("r", "Rerun strategy"),
@@ -173,6 +171,7 @@ pub(super) struct RunStrategyFormController {
         Field<SelectInput<String>>,
         Field<TextInput<DefaultTextInputParser<u64>>>,
         Field<SelectInput<String>>,
+        Field<TextInput<DefaultTextInputParser<f64>>>,
         Field<SelectInput<String>>,
     )>,
     selected_strategy: String,
@@ -195,6 +194,10 @@ impl RunStrategyFormController {
                     SelectInput::new(vec!["Yes".to_string(), "No".to_string()]),
                 ),
                 Field::new(
+                    "Amount of Dash to top up identities who run out. Enter 0 for no top ups.",
+                    TextInput::new("Enter Dash amount (decimals ok)"),
+                ),
+                Field::new(
                     "Confirm you would like to run the strategy",
                     SelectInput::new(vec!["Yes".to_string(), "No".to_string()]),
                 ),
@@ -207,7 +210,8 @@ impl RunStrategyFormController {
 impl FormController for RunStrategyFormController {
     fn on_event(&mut self, event: KeyEvent) -> FormStatus {
         match self.input.on_event(event) {
-            InputStatus::Done((mode, num_blocks, verify_proofs, confirm)) => {
+            InputStatus::Done((mode, num_blocks, verify_proofs, top_up_amount, confirm)) => {
+                let credit_amount = (top_up_amount * 100_000_000_000.0) as u64;
                 if confirm == "Yes" {
                     if verify_proofs == "Yes" {
                         if mode == "Block" {
@@ -218,6 +222,7 @@ impl FormController for RunStrategyFormController {
                                     num_blocks,
                                     true,
                                     true,
+                                    credit_amount,
                                 )),
                                 block: true,
                             }
@@ -229,6 +234,7 @@ impl FormController for RunStrategyFormController {
                                     num_blocks,
                                     true,
                                     false,
+                                    credit_amount,
                                 )),
                                 block: true,
                             }
@@ -242,6 +248,7 @@ impl FormController for RunStrategyFormController {
                                     num_blocks,
                                     false,
                                     true,
+                                    credit_amount,
                                 )),
                                 block: true,
                             }
@@ -253,6 +260,7 @@ impl FormController for RunStrategyFormController {
                                     num_blocks,
                                     false,
                                     false,
+                                    credit_amount,
                                 )),
                                 block: true,
                             }

--- a/src/ui/views/strategies/run_strategy.rs
+++ b/src/ui/views/strategies/run_strategy.rs
@@ -171,7 +171,7 @@ pub(super) struct RunStrategyFormController {
         Field<SelectInput<String>>,
         Field<TextInput<DefaultTextInputParser<u64>>>,
         Field<SelectInput<String>>,
-        Field<TextInput<DefaultTextInputParser<f64>>>,
+        // Field<TextInput<DefaultTextInputParser<f64>>>,
         Field<SelectInput<String>>,
     )>,
     selected_strategy: String,
@@ -193,10 +193,10 @@ impl RunStrategyFormController {
                     "Verify state transition proofs? (Only applies to block mode)",
                     SelectInput::new(vec!["Yes".to_string(), "No".to_string()]),
                 ),
-                Field::new(
-                    "Amount of Dash to top up identities who run out. Enter 0 for no top ups.",
-                    TextInput::new("Enter Dash amount (decimals ok)"),
-                ),
+                // Field::new(
+                //     "Amount of Dash to top up identities who run out. Enter 0 for no top ups.",
+                //     TextInput::new("Enter Dash amount (decimals ok)"),
+                // ),
                 Field::new(
                     "Confirm you would like to run the strategy",
                     SelectInput::new(vec!["Yes".to_string(), "No".to_string()]),
@@ -210,8 +210,8 @@ impl RunStrategyFormController {
 impl FormController for RunStrategyFormController {
     fn on_event(&mut self, event: KeyEvent) -> FormStatus {
         match self.input.on_event(event) {
-            InputStatus::Done((mode, num_blocks, verify_proofs, top_up_amount, confirm)) => {
-                let credit_amount = (top_up_amount * 100_000_000_000.0) as u64;
+            InputStatus::Done((mode, num_blocks, verify_proofs, confirm)) => {
+                let credit_amount = (0.0 * 100_000_000_000.0) as u64;
                 if confirm == "Yes" {
                     if verify_proofs == "Yes" {
                         if mode == "Block" {

--- a/supporting_files/contract/dashpay-contract-all-mutable-update-1.json
+++ b/supporting_files/contract/dashpay-contract-all-mutable-update-1.json
@@ -2,7 +2,7 @@
     "$format_version": "0",
     "id": "8MjTnX7JUbGfYYswyuCtHU7ZqcYU9s1fUaNiqD9s5tEw",
     "ownerId": "2QjL594djCH2NyDsn45vd6yQjEDHupMKo7CEGVTHtQxU",
-    "version": 1,
+    "version": 2,
     "documentSchemas": {
         "profile": {
             "type": "object",

--- a/supporting_files/contract/dashpay-contract-all-mutable-update-2.json
+++ b/supporting_files/contract/dashpay-contract-all-mutable-update-2.json
@@ -2,7 +2,7 @@
     "$format_version": "0",
     "id": "8MjTnX7JUbGfYYswyuCtHU7ZqcYU9s1fUaNiqD9s5tEw",
     "ownerId": "2QjL594djCH2NyDsn45vd6yQjEDHupMKo7CEGVTHtQxU",
-    "version": 2,
+    "version": 3,
     "documentSchemas": {
         "profileBest": {
             "type": "object",

--- a/supporting_files/contract/dashpay-contract-all-mutable.json
+++ b/supporting_files/contract/dashpay-contract-all-mutable.json
@@ -2,7 +2,7 @@
     "$format_version": "0",
     "id": "8MjTnX7JUbGfYYswyuCtHU7ZqcYU9s1fUaNiqD9s5tEw",
     "ownerId": "2QjL594djCH2NyDsn45vd6yQjEDHupMKo7CEGVTHtQxU",
-    "version": 0,
+    "version": 1,
     "documentSchemas": {
         "profile": {
             "type": "object",

--- a/supporting_files/contract/dashpay-variant-1.json
+++ b/supporting_files/contract/dashpay-variant-1.json
@@ -2,7 +2,7 @@
     "$format_version": "0",
     "id": "8MjTnX7JUbGfYYswyuCtHU7ZqcYU9s1fUaNiqD9s5tEw",
     "ownerId": "2QjL594djCH2NyDsn45vd6yQjEDHupMKo7CEGVTHtQxU",
-    "version": 0,
+    "version": 1,
     "documentSchemas": {
         "profile": {
             "type": "object",

--- a/supporting_files/contract/dashpay-variant-2.json
+++ b/supporting_files/contract/dashpay-variant-2.json
@@ -2,7 +2,7 @@
     "$format_version": "0",
     "id": "8MjTnX7JUbGfYYswyuCtHU7ZqcYU9s1fUaNiqD9s5tEw",
     "ownerId": "2QjL594djCH2NyDsn45vd6yQjEDHupMKo7CEGVTHtQxU",
-    "version": 0,
+    "version": 1,
     "documentSchemas": {
         "profile": {
             "type": "object",

--- a/supporting_files/contract/dashpay-variant-3.json
+++ b/supporting_files/contract/dashpay-variant-3.json
@@ -2,7 +2,7 @@
     "$format_version": "0",
     "id": "8MjTnX7JUbGfYYswyuCtHU7ZqcYU9s1fUaNiqD9s5tEw",
     "ownerId": "2QjL594djCH2NyDsn45vd6yQjEDHupMKo7CEGVTHtQxU",
-    "version": 0,
+    "version": 1,
     "documentSchemas": {
         "profile": {
             "type": "object",

--- a/supporting_files/contract/dashpay-variant-4.json
+++ b/supporting_files/contract/dashpay-variant-4.json
@@ -2,7 +2,7 @@
     "$format_version": "0",
     "id": "8MjTnX7JUbGfYYswyuCtHU7ZqcYU9s1fUaNiqD9s5tEw",
     "ownerId": "2QjL594djCH2NyDsn45vd6yQjEDHupMKo7CEGVTHtQxU",
-    "version": 0,
+    "version": 1,
     "documentSchemas": {
         "profile": {
             "type": "object",

--- a/supporting_files/contract/dashpay-variant-5.json
+++ b/supporting_files/contract/dashpay-variant-5.json
@@ -2,7 +2,7 @@
     "$format_version": "0",
     "id": "8MjTnX7JUbGfYYswyuCtHU7ZqcYU9s1fUaNiqD9s5tEw",
     "ownerId": "2QjL594djCH2NyDsn45vd6yQjEDHupMKo7CEGVTHtQxU",
-    "version": 0,
+    "version": 1,
     "documentSchemas": {
         "profile": {
             "type": "object",

--- a/supporting_files/contract/dpns_contract_preorder.json
+++ b/supporting_files/contract/dpns_contract_preorder.json
@@ -2,7 +2,7 @@
     "$format_version": "0",
     "id": "8BcTnX7JUbGfYYswyuCtHU7ZqcYU9s1fUaNiqD9s5tEw",
     "ownerId": "2PjL594djCH2NyDsn45vd6yQjEDHupMKo7CEGVTHtQxU",
-    "version": 0,
+    "version": 1,
     "documentSchemas": {
         "preorder": {
             "type": "object",


### PR DESCRIPTION
Added a counter that keeps track of how many documents an identity has in the mempool for each contract. In strategy-tests lib, we only allow those with less than 24 in the mempool to submit another document.

This entailed waiting for state transition result in "time mode". Since we are doubling the interactions with nodes (1 query for every broadcast), we can only broadcast half the STs now on testnet before the rate limiter blocks us.

Also fixed an issue with asset lock proofs.