### PR TITLE
feat: dpns registrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,7 +997,8 @@ dependencies = [
 
 [[package]]
 name = "dapi-grpc"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
 dependencies = [
  "dapi-grpc-macros",
  "futures-core",
@@ -1013,7 +1014,8 @@ dependencies = [
 
 [[package]]
 name = "dapi-grpc-macros"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
 dependencies = [
  "heck 0.5.0",
  "quote",
@@ -1057,7 +1059,8 @@ dependencies = [
 
 [[package]]
 name = "dash-sdk"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
 dependencies = [
  "async-trait",
  "bincode",
@@ -1161,7 +1164,8 @@ dependencies = [
 
 [[package]]
 name = "dashpay-contract"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -1171,7 +1175,8 @@ dependencies = [
 
 [[package]]
 name = "data-contracts"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
 dependencies = [
  "dashpay-contract",
  "dpns-contract",
@@ -1252,7 +1257,8 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpns-contract"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -1262,7 +1268,8 @@ dependencies = [
 
 [[package]]
 name = "dpp"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1308,7 +1315,8 @@ dependencies = [
 
 [[package]]
 name = "drive"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
 dependencies = [
  "arc-swap",
  "base64 0.21.7",
@@ -1342,7 +1350,8 @@ dependencies = [
 
 [[package]]
 name = "drive-proof-verifier"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
 dependencies = [
  "dapi-grpc",
  "dpp",
@@ -1562,7 +1571,8 @@ checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "feature-flags-contract"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2388,7 +2398,8 @@ dependencies = [
 
 [[package]]
 name = "json-schema-compatibility-validator"
-version = "0.25.16-rc.7"
+version = "0.25.16-rc.4"
+source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
 dependencies = [
  "json-patch",
  "once_cell",
@@ -2593,7 +2604,8 @@ dependencies = [
 
 [[package]]
 name = "masternode-reward-shares-contract"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -3138,7 +3150,8 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "platform-serialization"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
 dependencies = [
  "bincode",
  "platform-version",
@@ -3146,7 +3159,8 @@ dependencies = [
 
 [[package]]
 name = "platform-serialization-derive"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3156,7 +3170,8 @@ dependencies = [
 
 [[package]]
 name = "platform-value"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -3177,14 +3192,16 @@ dependencies = [
 
 [[package]]
 name = "platform-version"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "platform-versioning"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3714,7 +3731,8 @@ dependencies = [
 
 [[package]]
 name = "rs-dapi-client"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
 dependencies = [
  "backon",
  "chrono",
@@ -4189,7 +4207,8 @@ checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "simple-signer"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
 dependencies = [
  "bincode",
  "dashcore-rpc",
@@ -4310,7 +4329,8 @@ checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
 name = "strategy-tests"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
 dependencies = [
  "bincode",
  "dpp",
@@ -5554,7 +5574,8 @@ dependencies = [
 
 [[package]]
 name = "withdrawals-contract"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
+source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
 dependencies = [
  "num_enum",
  "platform-value",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "dapi-grpc"
-version = "1.0.0-dev.12"
+version = "1.0.0-dev.15"
 dependencies = [
  "dapi-grpc-macros",
  "futures-core",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "dapi-grpc-macros"
-version = "1.0.0-dev.12"
+version = "1.0.0-dev.15"
 dependencies = [
  "heck 0.5.0",
  "quote",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "dash-sdk"
-version = "1.0.0-dev.12"
+version = "1.0.0-dev.15"
 dependencies = [
  "async-trait",
  "bincode",
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "dashpay-contract"
-version = "1.0.0-dev.12"
+version = "1.0.0-dev.15"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -1171,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "data-contracts"
-version = "1.0.0-dev.12"
+version = "1.0.0-dev.15"
 dependencies = [
  "dashpay-contract",
  "dpns-contract",
@@ -1252,7 +1252,7 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpns-contract"
-version = "1.0.0-dev.12"
+version = "1.0.0-dev.15"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -1262,7 +1262,7 @@ dependencies = [
 
 [[package]]
 name = "dpp"
-version = "1.0.0-dev.12"
+version = "1.0.0-dev.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1308,7 +1308,7 @@ dependencies = [
 
 [[package]]
 name = "drive"
-version = "1.0.0-dev.12"
+version = "1.0.0-dev.15"
 dependencies = [
  "arc-swap",
  "base64 0.21.7",
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "drive-proof-verifier"
-version = "1.0.0-dev.12"
+version = "1.0.0-dev.15"
 dependencies = [
  "dapi-grpc",
  "dpp",
@@ -1562,7 +1562,7 @@ checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "feature-flags-contract"
-version = "1.0.0-dev.12"
+version = "1.0.0-dev.15"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2388,7 +2388,7 @@ dependencies = [
 
 [[package]]
 name = "json-schema-compatibility-validator"
-version = "0.25.16-rc.4"
+version = "0.25.16-rc.7"
 dependencies = [
  "json-patch",
  "once_cell",
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "masternode-reward-shares-contract"
-version = "1.0.0-dev.12"
+version = "1.0.0-dev.15"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -3138,7 +3138,7 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "platform-serialization"
-version = "1.0.0-dev.12"
+version = "1.0.0-dev.15"
 dependencies = [
  "bincode",
  "platform-version",
@@ -3146,7 +3146,7 @@ dependencies = [
 
 [[package]]
 name = "platform-serialization-derive"
-version = "1.0.0-dev.12"
+version = "1.0.0-dev.15"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3156,7 +3156,7 @@ dependencies = [
 
 [[package]]
 name = "platform-value"
-version = "1.0.0-dev.12"
+version = "1.0.0-dev.15"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -3177,14 +3177,14 @@ dependencies = [
 
 [[package]]
 name = "platform-version"
-version = "1.0.0-dev.12"
+version = "1.0.0-dev.15"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "platform-versioning"
-version = "1.0.0-dev.12"
+version = "1.0.0-dev.15"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3714,7 +3714,7 @@ dependencies = [
 
 [[package]]
 name = "rs-dapi-client"
-version = "1.0.0-dev.12"
+version = "1.0.0-dev.15"
 dependencies = [
  "backon",
  "chrono",
@@ -4189,7 +4189,7 @@ checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "simple-signer"
-version = "1.0.0-dev.12"
+version = "1.0.0-dev.15"
 dependencies = [
  "bincode",
  "dashcore-rpc",
@@ -4310,7 +4310,7 @@ checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
 name = "strategy-tests"
-version = "1.0.0-dev.12"
+version = "1.0.0-dev.15"
 dependencies = [
  "bincode",
  "dpp",
@@ -5554,7 +5554,7 @@ dependencies = [
 
 [[package]]
 name = "withdrawals-contract"
-version = "1.0.0-dev.12"
+version = "1.0.0-dev.15"
 dependencies = [
  "num_enum",
  "platform-value",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "dapi-grpc"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
 dependencies = [
  "dapi-grpc-macros",
  "futures-core",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "dapi-grpc-macros"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
 dependencies = [
  "heck 0.5.0",
  "quote",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "dash-sdk"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
 dependencies = [
  "async-trait",
  "bincode",
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "dashpay-contract"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -1171,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "data-contracts"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
 dependencies = [
  "dashpay-contract",
  "dpns-contract",
@@ -1252,7 +1252,7 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpns-contract"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -1262,7 +1262,7 @@ dependencies = [
 
 [[package]]
 name = "dpp"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1308,7 +1308,7 @@ dependencies = [
 
 [[package]]
 name = "drive"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
 dependencies = [
  "arc-swap",
  "base64 0.21.7",
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "drive-proof-verifier"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
 dependencies = [
  "dapi-grpc",
  "dpp",
@@ -1562,7 +1562,7 @@ checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "feature-flags-contract"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2388,7 +2388,7 @@ dependencies = [
 
 [[package]]
 name = "json-schema-compatibility-validator"
-version = "0.25.16-rc.7"
+version = "0.25.16-rc.4"
 dependencies = [
  "json-patch",
  "once_cell",
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "masternode-reward-shares-contract"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -3138,7 +3138,7 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "platform-serialization"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
 dependencies = [
  "bincode",
  "platform-version",
@@ -3146,7 +3146,7 @@ dependencies = [
 
 [[package]]
 name = "platform-serialization-derive"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3156,7 +3156,7 @@ dependencies = [
 
 [[package]]
 name = "platform-value"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -3177,14 +3177,14 @@ dependencies = [
 
 [[package]]
 name = "platform-version"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "platform-versioning"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3714,7 +3714,7 @@ dependencies = [
 
 [[package]]
 name = "rs-dapi-client"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
 dependencies = [
  "backon",
  "chrono",
@@ -4189,7 +4189,7 @@ checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "simple-signer"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
 dependencies = [
  "bincode",
  "dashcore-rpc",
@@ -4310,7 +4310,7 @@ checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
 name = "strategy-tests"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
 dependencies = [
  "bincode",
  "dpp",
@@ -5554,7 +5554,7 @@ dependencies = [
 
 [[package]]
 name = "withdrawals-contract"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.12"
 dependencies = [
  "num_enum",
  "platform-value",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,9 +309,9 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -997,8 +997,7 @@ dependencies = [
 
 [[package]]
 name = "dapi-grpc"
-version = "1.0.0-dev.12"
-source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
+version = "1.0.0-dev.15"
 dependencies = [
  "dapi-grpc-macros",
  "futures-core",
@@ -1014,8 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "dapi-grpc-macros"
-version = "1.0.0-dev.12"
-source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
+version = "1.0.0-dev.15"
 dependencies = [
  "heck 0.5.0",
  "quote",
@@ -1059,8 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "dash-sdk"
-version = "1.0.0-dev.12"
-source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
+version = "1.0.0-dev.15"
 dependencies = [
  "async-trait",
  "bincode",
@@ -1164,8 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "dashpay-contract"
-version = "1.0.0-dev.12"
-source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
+version = "1.0.0-dev.15"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -1175,8 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "data-contracts"
-version = "1.0.0-dev.12"
-source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
+version = "1.0.0-dev.15"
 dependencies = [
  "dashpay-contract",
  "dpns-contract",
@@ -1257,8 +1252,7 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpns-contract"
-version = "1.0.0-dev.12"
-source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
+version = "1.0.0-dev.15"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -1268,12 +1262,11 @@ dependencies = [
 
 [[package]]
 name = "dpp"
-version = "1.0.0-dev.12"
-source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
+version = "1.0.0-dev.15"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.22.0",
+ "base64 0.22.1",
  "bincode",
  "bls-signatures",
  "bs58 0.4.0",
@@ -1315,8 +1308,7 @@ dependencies = [
 
 [[package]]
 name = "drive"
-version = "1.0.0-dev.12"
-source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
+version = "1.0.0-dev.15"
 dependencies = [
  "arc-swap",
  "base64 0.21.7",
@@ -1350,8 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "drive-proof-verifier"
-version = "1.0.0-dev.12"
-source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
+version = "1.0.0-dev.15"
 dependencies = [
  "dapi-grpc",
  "dpp",
@@ -1571,8 +1562,7 @@ checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "feature-flags-contract"
-version = "1.0.0-dev.12"
-source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
+version = "1.0.0-dev.15"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2398,8 +2388,7 @@ dependencies = [
 
 [[package]]
 name = "json-schema-compatibility-validator"
-version = "0.25.16-rc.4"
-source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
+version = "0.25.16-rc.7"
 dependencies = [
  "json-patch",
  "once_cell",
@@ -2425,7 +2414,7 @@ source = "git+https://github.com/fominok/jsonschema-rs?branch=feat-unevaluated-p
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
- "base64 0.22.0",
+ "base64 0.22.1",
  "bytecount",
  "fancy-regex",
  "fraction",
@@ -2604,8 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "masternode-reward-shares-contract"
-version = "1.0.0-dev.12"
-source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
+version = "1.0.0-dev.15"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -3150,8 +3138,7 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "platform-serialization"
-version = "1.0.0-dev.12"
-source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
+version = "1.0.0-dev.15"
 dependencies = [
  "bincode",
  "platform-version",
@@ -3159,8 +3146,7 @@ dependencies = [
 
 [[package]]
 name = "platform-serialization-derive"
-version = "1.0.0-dev.12"
-source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
+version = "1.0.0-dev.15"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3170,10 +3156,9 @@ dependencies = [
 
 [[package]]
 name = "platform-value"
-version = "1.0.0-dev.12"
-source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
+version = "1.0.0-dev.15"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "bincode",
  "bs58 0.5.1",
  "ciborium",
@@ -3192,16 +3177,14 @@ dependencies = [
 
 [[package]]
 name = "platform-version"
-version = "1.0.0-dev.12"
-source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
+version = "1.0.0-dev.15"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "platform-versioning"
-version = "1.0.0-dev.12"
-source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
+version = "1.0.0-dev.15"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3639,7 +3622,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3731,8 +3714,7 @@ dependencies = [
 
 [[package]]
 name = "rs-dapi-client"
-version = "1.0.0-dev.12"
-source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
+version = "1.0.0-dev.15"
 dependencies = [
  "backon",
  "chrono",
@@ -3908,7 +3890,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "rustls-pki-types",
 ]
 
@@ -4207,8 +4189,7 @@ checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "simple-signer"
-version = "1.0.0-dev.12"
-source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
+version = "1.0.0-dev.15"
 dependencies = [
  "bincode",
  "dashcore-rpc",
@@ -4329,8 +4310,7 @@ checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
 name = "strategy-tests"
-version = "1.0.0-dev.12"
-source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
+version = "1.0.0-dev.15"
 dependencies = [
  "bincode",
  "dpp",
@@ -5102,7 +5082,7 @@ version = "2.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d11a831e3c0b56e438a28308e7c810799e3c118417f342d30ecec080105395cd"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "flate2",
  "log",
  "once_cell",
@@ -5574,8 +5554,7 @@ dependencies = [
 
 [[package]]
 name = "withdrawals-contract"
-version = "1.0.0-dev.12"
-source = "git+https://github.com/dashpay/platform?rev=63d06f6aaeb140a462e4c8e45a82774fc73ba806#63d06f6aaeb140a462e4c8e45a82774fc73ba806"
+version = "1.0.0-dev.15"
 dependencies = [
  "num_enum",
  "platform-value",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,23 +10,23 @@ strum = { version = "0.26.1", features = ["derive"] }
 tui-realm-stdlib = "1.3.1"
 tuirealm = "1.9.1"
 bs58 = "0.5.0"
-dpp = { path = "../platform/packages/rs-dpp", features = [
+dpp = { git = "https://github.com/dashpay/platform", rev = "63d06f6aaeb140a462e4c8e45a82774fc73ba806", features = [
     "client",
 ] }
-dash-sdk = { path = "../platform/packages/rs-sdk" }
-drive = { path = "../platform/packages/rs-drive" }
+dash-sdk = { git = "https://github.com/dashpay/platform", rev = "63d06f6aaeb140a462e4c8e45a82774fc73ba806" }
+drive = { git = "https://github.com/dashpay/platform", rev = "63d06f6aaeb140a462e4c8e45a82774fc73ba806" }
 thiserror = "1"
 serde = "1.0.197"
 serde_json = "1.0.114"
 toml = { version = "0.8.10", features = ["display"] }
-dapi-grpc = { path = "../platform/packages/dapi-grpc", features = [
+dapi-grpc = { git = "https://github.com/dashpay/platform", rev = "63d06f6aaeb140a462e4c8e45a82774fc73ba806", features = [
     "client",
 ] }
-rs-dapi-client = { path = "../platform/packages/rs-dapi-client" }
+rs-dapi-client = { git = "https://github.com/dashpay/platform", rev = "63d06f6aaeb140a462e4c8e45a82774fc73ba806" }
 tokio = { version = "1.36.0", features = ["full"] }
 bincode = { version = "2.0.0-rc.3", features = ["serde"] }
-strategy-tests = { path = "../platform/packages/strategy-tests" }
-simple-signer = { path = "../platform/packages/simple-signer" }
+strategy-tests = { git = "https://github.com/dashpay/platform", rev = "63d06f6aaeb140a462e4c8e45a82774fc73ba806" }
+simple-signer = { git = "https://github.com/dashpay/platform", rev = "63d06f6aaeb140a462e4c8e45a82774fc73ba806" }
 reqwest = { version = "0.12.3", features = ["json"] }
 hex = { version = "0.4.3" }
 itertools = "0.12.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,23 +10,23 @@ strum = { version = "0.26.1", features = ["derive"] }
 tui-realm-stdlib = "1.3.1"
 tuirealm = "1.9.1"
 bs58 = "0.5.0"
-dpp = { git = "https://github.com/dashpay/platform", rev = "63d06f6aaeb140a462e4c8e45a82774fc73ba806", features = [
+dpp = { path = "../platform/packages/rs-dpp", features = [
     "client",
 ] }
-dash-sdk = { git = "https://github.com/dashpay/platform", rev = "63d06f6aaeb140a462e4c8e45a82774fc73ba806" }
-drive = { git = "https://github.com/dashpay/platform", rev = "63d06f6aaeb140a462e4c8e45a82774fc73ba806" }
+dash-sdk = { path = "../platform/packages/rs-sdk" }
+drive = { path = "../platform/packages/rs-drive" }
 thiserror = "1"
 serde = "1.0.197"
 serde_json = "1.0.114"
 toml = { version = "0.8.10", features = ["display"] }
-dapi-grpc = { git = "https://github.com/dashpay/platform", rev = "63d06f6aaeb140a462e4c8e45a82774fc73ba806", features = [
+dapi-grpc = { path = "../platform/packages/dapi-grpc", features = [
     "client",
 ] }
-rs-dapi-client = { git = "https://github.com/dashpay/platform", rev = "63d06f6aaeb140a462e4c8e45a82774fc73ba806" }
+rs-dapi-client = { path = "../platform/packages/rs-dapi-client" }
 tokio = { version = "1.36.0", features = ["full"] }
 bincode = { version = "2.0.0-rc.3", features = ["serde"] }
-strategy-tests = { git = "https://github.com/dashpay/platform", rev = "63d06f6aaeb140a462e4c8e45a82774fc73ba806" }
-simple-signer = { git = "https://github.com/dashpay/platform", rev = "63d06f6aaeb140a462e4c8e45a82774fc73ba806" }
+strategy-tests = { path = "../platform/packages/strategy-tests" }
+simple-signer = { path = "../platform/packages/simple-signer" }
 reqwest = { version = "0.12.3", features = ["json"] }
 hex = { version = "0.4.3" }
 itertools = "0.12.1"

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -135,6 +135,8 @@ pub(crate) enum AppStateUpdate<'s> {
     ClearedLoadedIdentity,
     ClearedLoadedWallet,
     IdentityCreditsTransferred,
+    DPNSNameRegistered(String),
+    DPNSNameRegistrationFailed,
 }
 
 /// Represents the result of completing a strategy.
@@ -253,7 +255,7 @@ impl Drop for Backend<'_> {
 
 fn stringify_result<T: Serialize, E: Display>(result: Result<T, E>) -> Result<String, String> {
     match result {
-        Ok(data) => Ok(as_toml(&data)),
+        Ok(data) => Ok(as_json_string(&data)),
         Err(e) => Err(e.to_string()),
     }
 }
@@ -263,7 +265,7 @@ fn stringify_result_keep_item<T: Serialize, E: Display>(
 ) -> Result<(T, String), String> {
     match result {
         Ok(data) => {
-            let toml = as_toml(&data);
+            let toml = as_json_string(&data);
             Ok((data, toml))
         }
         Err(e) => Err(e.to_string()),
@@ -272,4 +274,8 @@ fn stringify_result_keep_item<T: Serialize, E: Display>(
 
 pub(crate) fn as_toml<T: Serialize>(value: &T) -> String {
     toml::to_string_pretty(&value).unwrap_or("Cannot serialize as TOML".to_owned())
+}
+
+pub(crate) fn as_json_string<T: Serialize>(value: &T) -> String {
+    serde_json::to_string_pretty(&value).unwrap_or("Cannot serialize as json string".to_owned())
 }

--- a/src/backend/contracts.rs
+++ b/src/backend/contracts.rs
@@ -1,16 +1,21 @@
 //! Contracts backend.
-use dash_sdk::{platform::Fetch, Sdk};
+use std::sync::Arc;
+
+use dash_sdk::{
+    platform::{DocumentQuery, Fetch},
+    Sdk,
+};
 use dpp::{
     data_contract::accessors::v0::DataContractV0Getters,
-    platform_value::string_encoding::Encoding,
+    document::{Document, DocumentV0Getters},
+    platform_value::{string_encoding::Encoding, Value},
     prelude::{DataContract, Identifier},
     system_data_contracts::{dashpay_contract, dpns_contract},
 };
+use drive::query::{WhereClause, WhereOperator};
 use tokio::sync::Mutex;
 
-use super::{
-    as_json_string, as_toml, state::KnownContractsMap, AppStateUpdate, BackendEvent, Task,
-};
+use super::{as_json_string, state::KnownContractsMap, AppStateUpdate, BackendEvent, Task};
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum ContractTask {
@@ -19,9 +24,6 @@ pub(crate) enum ContractTask {
     RemoveContract(String),
     FetchContract(String),
 }
-
-const DASHPAY_CONTRACT_NAME: &str = "dashpay";
-const DPNS_CONTRACT_NAME: &str = "dpns";
 
 pub(super) async fn run_contract_task<'s>(
     sdk: &Sdk,
@@ -36,7 +38,13 @@ pub(super) async fn run_contract_task<'s>(
                 Ok(Some(data_contract)) => {
                     let contract_str = as_json_string(&data_contract);
                     let mut contracts_lock = known_contracts.lock().await;
-                    contracts_lock.insert(DASHPAY_CONTRACT_NAME.to_owned(), data_contract);
+
+                    let contract_name = match get_dpns_name(sdk, &data_contract.id()).await {
+                        Some(name) => name,
+                        None => data_contract.id().to_string(Encoding::Base58),
+                    };
+
+                    contracts_lock.insert(contract_name, data_contract);
 
                     BackendEvent::TaskCompletedStateChange {
                         task: Task::Contract(task),
@@ -60,10 +68,13 @@ pub(super) async fn run_contract_task<'s>(
                 Ok(Some(data_contract)) => {
                     let contract_str = as_json_string(&data_contract);
                     let mut contracts_lock = known_contracts.lock().await;
-                    contracts_lock.insert(
-                        data_contract.id().to_string(Encoding::Base58),
-                        data_contract,
-                    );
+
+                    let contract_name = match get_dpns_name(sdk, &data_contract.id()).await {
+                        Some(name) => name,
+                        None => data_contract.id().to_string(Encoding::Base58),
+                    };
+
+                    contracts_lock.insert(contract_name, data_contract);
 
                     BackendEvent::TaskCompletedStateChange {
                         task: Task::Contract(task),
@@ -115,5 +126,41 @@ pub(super) async fn run_contract_task<'s>(
                 },
             }
         }
+    }
+}
+
+pub async fn get_dpns_name(sdk: &Sdk, id: &Identifier) -> Option<String> {
+    if let Some(dpns_contract) =
+        match DataContract::fetch(&sdk, Into::<Identifier>::into(dpns_contract::ID_BYTES)).await {
+            Ok(contract) => match contract {
+                Some(contract) => Some(contract),
+                None => None,
+            },
+            Err(_) => None,
+        }
+    {
+        let document_query = DocumentQuery {
+            data_contract: Arc::new(dpns_contract),
+            document_type_name: "domain".to_string(),
+            where_clauses: vec![WhereClause {
+                field: "label".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Identifier(id.to_buffer()),
+            }],
+            order_by_clauses: vec![],
+            limit: 1,
+            start: None,
+        };
+        match Document::fetch(sdk, document_query).await {
+            Ok(document) => {
+                let some_document = document.unwrap();
+                let properties = some_document.properties();
+                let label = properties.get("label").unwrap();
+                Some(label.to_string())
+            }
+            Err(_) => None,
+        }
+    } else {
+        None
     }
 }

--- a/src/backend/error.rs
+++ b/src/backend/error.rs
@@ -34,8 +34,12 @@ pub(crate) enum Error {
     IdentityWithdrawalError(String),
     #[error("Identity refresh error: {0}")]
     IdentityRefreshError(String),
+    #[error("Identity error: {0}")]
+    IdentityError(String),
     #[error("Document Signing error: {0}")]
     DocumentSigningError(String),
+    #[error("DPNS error: {0}")]
+    DPNSError(String),
 }
 
 impl From<dpp::platform_value::Error> for Error {

--- a/src/backend/identities.rs
+++ b/src/backend/identities.rs
@@ -5,6 +5,7 @@ use std::{
     time::Duration,
 };
 
+use clap::Id;
 use dapi_grpc::{
     core::v0::{
         BroadcastTransactionRequest, GetBlockchainStatusRequest, GetTransactionRequest,
@@ -25,18 +26,29 @@ use dash_sdk::{
     },
     Sdk,
 };
-use dpp::identity::SecurityLevel;
 use dpp::{
-    consensus::basic::state_transition,
     dashcore::{psbt::serialize::Serialize, Address, PrivateKey, Transaction},
+    data_contract::{
+        accessors::v0::DataContractV0Getters,
+        document_type::{
+            accessors::DocumentTypeV0Getters,
+            random_document::{CreateRandomDocument, DocumentFieldFillSize, DocumentFieldFillType},
+            v0::DocumentTypeV0,
+        },
+    },
+    data_contracts::dpns_contract,
+    document::{DocumentV0Getters, DocumentV0Setters},
     identity::{
         accessors::{IdentityGettersV0, IdentitySettersV0},
         identity_public_key::{accessors::v0::IdentityPublicKeyGettersV0, v0::IdentityPublicKeyV0},
         KeyType, PartialIdentity, Purpose as KeyPurpose, SecurityLevel as KeySecurityLevel,
     },
-    platform_value::{string_encoding::Encoding, Identifier},
+    platform_value::{string_encoding::Encoding, Bytes32, Identifier},
     prelude::{AssetLockProof, Identity, IdentityPublicKey},
     state_transition::{
+        documents_batch_transition::{
+            methods::v0::DocumentsBatchTransitionMethodsV0, DocumentsBatchTransition,
+        },
         identity_credit_transfer_transition::{
             accessors::IdentityCreditTransferTransitionAccessorsV0,
             IdentityCreditTransferTransition,
@@ -48,10 +60,12 @@ use dpp::{
         public_key_in_creation::v0::IdentityPublicKeyInCreationV0,
         StateTransition,
     },
+    util::{hash::hash_double, strings::convert_to_homograph_safe_chars},
     version::PlatformVersion,
 };
+use dpp::{data_contract::DataContract, identity::SecurityLevel};
 use dpp::{identity::Purpose, ProtocolError};
-use rand::{rngs::StdRng, SeedableRng};
+use rand::{rngs::StdRng, Rng, SeedableRng};
 use rs_dapi_client::{DapiRequestExecutor, RequestSettings};
 use simple_signer::signer::SimpleSigner;
 use tokio::sync::{MappedMutexGuard, MutexGuard};
@@ -87,6 +101,7 @@ pub enum IdentityTask {
     },
     ClearLoadedIdentity,
     TransferCredits(String, f64),
+    RegisterDPNSName(String),
 }
 
 impl AppState {
@@ -318,7 +333,170 @@ impl AppState {
                     }
                 }
             }
+            IdentityTask::RegisterDPNSName(ref name) => {
+                let result = self.register_dpns_name(sdk, name).await;
+                let execution_result = result
+                    .as_ref()
+                    .map(|_| "DPNS name registration successful".into())
+                    .map_err(|e| e.to_string());
+                let app_state_update = match result {
+                    Ok(_) => AppStateUpdate::DPNSNameRegistered(name.clone()),
+                    Err(_) => AppStateUpdate::DPNSNameRegistrationFailed,
+                };
+
+                BackendEvent::TaskCompletedStateChange {
+                    task: Task::Identity(task),
+                    execution_result,
+                    app_state_update,
+                }
+            }
         }
+    }
+
+    pub(crate) async fn register_dpns_name(&self, sdk: &Sdk, name: &str) -> Result<(), Error> {
+        let mut rng = StdRng::from_entropy();
+        let platform_version = PlatformVersion::latest();
+
+        let loaded_identity = self.loaded_identity.lock().await;
+        let identity = loaded_identity
+            .as_ref()
+            .ok_or_else(|| Error::IdentityError("No loaded identity".to_string()))?;
+
+        let dpns_contract = match DataContract::fetch(
+            &sdk,
+            Into::<Identifier>::into(dpns_contract::ID_BYTES),
+        )
+        .await
+        {
+            Ok(contract) => contract.unwrap(),
+            Err(e) => return Err(Error::SdkError(e)),
+        };
+        let preorder_document_type = dpns_contract
+            .document_type_for_name("preorder")
+            .map_err(|_| Error::DPNSError("DPNS preorder document type not found".to_string()))?;
+        let domain_document_type = dpns_contract
+            .document_type_for_name("domain")
+            .map_err(|_| Error::DPNSError("DPNS domain document type not found".to_string()))?;
+
+        let entropy = Bytes32::random_with_rng(&mut rng);
+
+        let mut preorder_document = preorder_document_type
+            .random_document_with_identifier_and_entropy(
+                &mut rng,
+                identity.id(),
+                entropy,
+                DocumentFieldFillType::FillIfNotRequired,
+                DocumentFieldFillSize::AnyDocumentFillSize,
+                &platform_version,
+            )?;
+        let mut domain_document = domain_document_type
+            .random_document_with_identifier_and_entropy(
+                &mut rng,
+                identity.id(),
+                entropy,
+                DocumentFieldFillType::FillIfNotRequired,
+                DocumentFieldFillSize::AnyDocumentFillSize,
+                &platform_version,
+            )?;
+
+        let salt: [u8; 32] = rng.gen();
+        let mut salted_domain_buffer: Vec<u8> = vec![];
+        salted_domain_buffer.extend(salt);
+        salted_domain_buffer.extend((convert_to_homograph_safe_chars(name) + ".dash").as_bytes());
+        let salted_domain_hash = hash_double(salted_domain_buffer);
+
+        preorder_document.set("saltedDomainHash", salted_domain_hash.into());
+        domain_document.set("parentDomainName", "dash".into());
+        domain_document.set("normalizedParentDomainName", "dash".into());
+        domain_document.set("label", name.into());
+        domain_document.set(
+            "normalizedLabel",
+            convert_to_homograph_safe_chars(name).into(),
+        );
+        domain_document.set(
+            "records.dashUniqueIdentityId",
+            domain_document.owner_id().into(),
+        );
+        domain_document.set("subdomainRules.allowSubdomains", false.into());
+        domain_document.set("preorderSalt", salt.into());
+
+        let identity_contract_nonce = match sdk
+            .get_identity_contract_nonce(identity.id(), dpns_contract.id(), true, None)
+            .await
+        {
+            Ok(nonce) => nonce,
+            Err(e) => return Err(Error::SdkError(e)),
+        };
+
+        // TODO this is used in strategy tests too. It should be a function.
+        // Get signer from loaded_identity
+        // Convert loaded_identity to SimpleSigner
+        let identity_private_keys_lock = self.identity_private_keys.lock().await;
+        let signer = {
+            let mut new_signer = SimpleSigner::default();
+            let Identity::V0(identity_v0) = &*identity;
+            for (key_id, public_key) in &identity_v0.public_keys {
+                let identity_key_tuple = (identity_v0.id, *key_id);
+                if let Some(private_key_bytes) = identity_private_keys_lock.get(&identity_key_tuple)
+                {
+                    new_signer
+                        .private_keys
+                        .insert(public_key.clone(), private_key_bytes.clone());
+                }
+            }
+            new_signer
+        };
+        drop(identity_private_keys_lock);
+
+        let preorder_transition =
+            DocumentsBatchTransition::new_document_creation_transition_from_document(
+                preorder_document,
+                preorder_document_type,
+                entropy.0,
+                identity
+                    .get_first_public_key_matching(
+                        Purpose::AUTHENTICATION,
+                        HashSet::from([SecurityLevel::CRITICAL]),
+                        HashSet::from([KeyType::ECDSA_SECP256K1, KeyType::BLS12_381]),
+                    )
+                    .expect("expected to get a signing key"),
+                identity_contract_nonce,
+                0,
+                &signer,
+                &platform_version,
+                None,
+                None,
+                None,
+            )?;
+
+        let domain_transition =
+            DocumentsBatchTransition::new_document_creation_transition_from_document(
+                domain_document,
+                domain_document_type,
+                entropy.0,
+                identity
+                    .get_first_public_key_matching(
+                        Purpose::AUTHENTICATION,
+                        HashSet::from([SecurityLevel::CRITICAL]),
+                        HashSet::from([KeyType::ECDSA_SECP256K1, KeyType::BLS12_381]),
+                    )
+                    .expect("expected to get a signing key"),
+                identity_contract_nonce + 1,
+                0,
+                &signer,
+                &platform_version,
+                None,
+                None,
+                None,
+            )?;
+
+        tracing::info!("Broadcasting preorder document...");
+        preorder_transition.broadcast(sdk).await?;
+
+        tracing::info!("Broadcasting domain document...");
+        domain_transition.broadcast(sdk).await?;
+
+        Ok(())
     }
 
     pub(crate) async fn refresh_identity<'s>(

--- a/src/backend/platform_info.rs
+++ b/src/backend/platform_info.rs
@@ -13,7 +13,7 @@ use dpp::{
     version::ProtocolVersionVoteCount,
 };
 
-use crate::backend::{as_toml, BackendEvent, Task};
+use crate::backend::{as_json_string, BackendEvent, Task};
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum PlatformInfoTask {
@@ -120,7 +120,7 @@ pub(super) async fn run_platform_task<'s>(sdk: &Sdk, task: PlatformInfoTask) -> 
 
             match ExtendedEpochInfo::fetch_many(&sdk, query).await {
                 Ok(epoch_infos) => {
-                    let epoch_info = as_toml(&epoch_infos);
+                    let epoch_info = as_json_string(&epoch_infos);
 
                     BackendEvent::TaskCompleted {
                         task: Task::PlatformInfo(task),

--- a/src/backend/strategies.rs
+++ b/src/backend/strategies.rs
@@ -682,7 +682,7 @@ pub async fn run_strategy_task<'s>(
                     );
                 }
                 strategy.start_identities = StartIdentities {
-                    number_of_identities: count,
+                    number_of_identities: count as u16,
                     keys_per_identity: keys_count,
                     starting_balances: balance,
                     extra_keys,
@@ -1127,6 +1127,7 @@ pub async fn run_strategy_task<'s>(
                             &mut signer,
                             &mut identity_nonce_counter,
                             &mut contract_nonce_counter,
+                            mempool_document_counter.clone(),
                             &mut rng,
                             &StrategyConfig {
                                 start_block_height: initial_block_info.height,

--- a/src/backend/strategies.rs
+++ b/src/backend/strategies.rs
@@ -682,7 +682,7 @@ pub async fn run_strategy_task<'s>(
                     );
                 }
                 strategy.start_identities = StartIdentities {
-                    number_of_identities: count as u16,
+                    number_of_identities: count,
                     keys_per_identity: keys_count,
                     starting_balances: balance,
                     extra_keys,
@@ -1127,7 +1127,7 @@ pub async fn run_strategy_task<'s>(
                             &mut signer,
                             &mut identity_nonce_counter,
                             &mut contract_nonce_counter,
-                            mempool_document_counter.clone(),
+                            // mempool_document_counter.clone(),
                             &mut rng,
                             &StrategyConfig {
                                 start_block_height: initial_block_info.height,

--- a/src/backend/strategies.rs
+++ b/src/backend/strategies.rs
@@ -95,7 +95,7 @@ pub enum StrategyTask {
     },
     SetStartIdentities {
         strategy_name: String,
-        count: u8,
+        count: u16,
         keys_count: u8,
         balance: u64,
         add_transfer_key: bool,

--- a/src/backend/strategies.rs
+++ b/src/backend/strategies.rs
@@ -682,7 +682,7 @@ pub async fn run_strategy_task<'s>(
                     );
                 }
                 strategy.start_identities = StartIdentities {
-                    number_of_identities: count,
+                    number_of_identities: count as u16,
                     keys_per_identity: keys_count,
                     starting_balances: balance,
                     extra_keys,
@@ -1102,6 +1102,7 @@ pub async fn run_strategy_task<'s>(
                 let mut new_contract_ids = Vec::new(); // Will capture the ids of newly created data contracts
                 let oks = Arc::new(AtomicUsize::new(0)); // Atomic counter for successful broadcasts
                 let errs = Arc::new(AtomicUsize::new(0)); // Atomic counter for failed broadcasts
+                let mempool_document_counter = BTreeMap::<(Identifier, Identifier), u64>::new(); // Map to track how many documents an identity has in the mempool per contract
 
                 // Now loop through the number of blocks or seconds the user asked for, preparing and processing state transitions
                 while (block_mode && current_block_info.height < (initial_block_info.height + num_blocks_or_seconds + 2)) // +2 because we don't count the first two initialization blocks
@@ -1126,6 +1127,7 @@ pub async fn run_strategy_task<'s>(
                             &mut signer,
                             &mut identity_nonce_counter,
                             &mut contract_nonce_counter,
+                            mempool_document_counter.clone(),
                             &mut rng,
                             &StrategyConfig {
                                 start_block_height: initial_block_info.height,

--- a/src/backend/strategies.rs
+++ b/src/backend/strategies.rs
@@ -682,7 +682,7 @@ pub async fn run_strategy_task<'s>(
                     );
                 }
                 strategy.start_identities = StartIdentities {
-                    number_of_identities: count as u16,
+                    number_of_identities: count,
                     keys_per_identity: keys_count,
                     starting_balances: balance,
                     extra_keys,
@@ -1127,7 +1127,6 @@ pub async fn run_strategy_task<'s>(
                             &mut signer,
                             &mut identity_nonce_counter,
                             &mut contract_nonce_counter,
-                            mempool_document_counter.clone(),
                             &mut rng,
                             &StrategyConfig {
                                 start_block_height: initial_block_info.height,

--- a/src/ui/views/contracts/document_type.rs
+++ b/src/ui/views/contracts/document_type.rs
@@ -22,7 +22,7 @@ use tuirealm::{
 use self::broadcast_random_documents::BroadcastRandomDocumentsCountForm;
 use crate::{
     backend::{
-        as_toml, documents::DocumentTask, AppState, BackendEvent, CompletedTaskPayload, Task,
+        as_json_string, documents::DocumentTask, AppState, BackendEvent, CompletedTaskPayload, Task,
     },
     ui::{
         form::{
@@ -136,7 +136,7 @@ impl DocumentTypeScreenController {
             .document_type_for_name(&document_type_name)
             .expect("expected a document type")
             .to_owned_document_type();
-        let document_type_str = as_toml(document_type.properties());
+        let document_type_str = as_json_string(document_type.properties());
         let info = Info::new_scrollable(&document_type_str);
 
         DocumentTypeScreenController {

--- a/src/ui/views/documents.rs
+++ b/src/ui/views/documents.rs
@@ -12,7 +12,7 @@ use tuirealm::{
 };
 
 use crate::{
-    backend::as_toml,
+    backend::as_json_string,
     ui::screen::{
         widgets::info::Info, ScreenCommandKey, ScreenController, ScreenFeedback, ScreenToggleKey,
     },
@@ -54,7 +54,7 @@ impl DocumentsQuerysetScreenController {
         let document_view = Info::new_scrollable(
             &current_batch
                 .first_key_value()
-                .map(|(_, v)| as_toml(v))
+                .map(|(_, v)| as_json_string(v))
                 .unwrap_or_else(String::new),
         );
 
@@ -70,7 +70,7 @@ impl DocumentsQuerysetScreenController {
             &self
                 .current_batch
                 .get(self.document_select.state().unwrap_one().unwrap_usize())
-                .map(|v| as_toml(&v))
+                .map(|v| as_json_string(&v))
                 .unwrap_or_else(String::new),
         );
     }

--- a/src/ui/views/identities.rs
+++ b/src/ui/views/identities.rs
@@ -130,6 +130,14 @@ impl ScreenController for IdentitiesScreenController {
                 ScreenFeedback::Redraw
             }
 
+            Event::Backend(BackendEvent::TaskCompleted {
+                task: Task::Identity(_),
+                execution_result,
+            }) => {
+                self.info = Info::new_from_result(execution_result);
+                ScreenFeedback::Redraw
+            }
+
             _ => ScreenFeedback::None,
         }
     }

--- a/src/ui/views/identities.rs
+++ b/src/ui/views/identities.rs
@@ -21,10 +21,11 @@ use crate::{
     Event,
 };
 
-const COMMAND_KEYS: [ScreenCommandKey; 3] = [
+const COMMAND_KEYS: [ScreenCommandKey; 4] = [
     ScreenCommandKey::new("q", "Back to Main"),
     ScreenCommandKey::new("i", "Get Identity by ID"),
     ScreenCommandKey::new("t", "Transfer credits"),
+    ScreenCommandKey::new("r", "Register DPNS name"),
 ];
 
 pub(crate) struct IdentitiesScreenController {
@@ -81,6 +82,11 @@ impl ScreenController for IdentitiesScreenController {
                 ScreenFeedback::Redraw
             }
 
+            Event::Key(KeyEvent {
+                code: Key::Char('r'),
+                modifiers: KeyModifiers::NONE,
+            }) => ScreenFeedback::Form(Box::new(RegisterDPNSNameFormController::new())),
+
             Event::Key(k) => {
                 let redraw_info = self.info.on_event(k);
                 if redraw_info {
@@ -108,6 +114,15 @@ impl ScreenController for IdentitiesScreenController {
 
             Event::Backend(BackendEvent::TaskCompletedStateChange {
                 task: Task::Identity(IdentityTask::TransferCredits(..)),
+                execution_result,
+                app_state_update: _,
+            }) => {
+                self.info = Info::new_from_result(execution_result);
+                ScreenFeedback::Redraw
+            }
+
+            Event::Backend(BackendEvent::TaskCompletedStateChange {
+                task: Task::Identity(IdentityTask::RegisterDPNSName(..)),
                 execution_result,
                 app_state_update: _,
             }) => {
@@ -218,5 +233,51 @@ impl FormController for TransferCreditsFormController {
 
     fn steps_number(&self) -> u8 {
         2
+    }
+}
+
+pub(crate) struct RegisterDPNSNameFormController {
+    input: TextInput<DefaultTextInputParser<String>>,
+}
+
+impl RegisterDPNSNameFormController {
+    fn new() -> Self {
+        RegisterDPNSNameFormController {
+            input: TextInput::new(
+                "DPNS name (example: enter \"something\" if you want \"something.dash\")",
+            ),
+        }
+    }
+}
+
+impl FormController for RegisterDPNSNameFormController {
+    fn on_event(&mut self, event: KeyEvent) -> FormStatus {
+        match self.input.on_event(event) {
+            InputStatus::Done(value) => FormStatus::Done {
+                task: Task::Identity(IdentityTask::RegisterDPNSName(value)),
+                block: true,
+            },
+            status => status.into(),
+        }
+    }
+
+    fn step_view(&mut self, frame: &mut Frame, area: tuirealm::tui::prelude::Rect) {
+        self.input.view(frame, area);
+    }
+
+    fn form_name(&self) -> &'static str {
+        "Register DPNS Name"
+    }
+
+    fn step_name(&self) -> &'static str {
+        "DPNS Name"
+    }
+
+    fn step_index(&self) -> u8 {
+        0
+    }
+
+    fn steps_number(&self) -> u8 {
+        1
     }
 }

--- a/src/ui/views/strategies/start_identities.rs
+++ b/src/ui/views/strategies/start_identities.rs
@@ -181,7 +181,7 @@ impl ScreenController for StartIdentitiesScreenController {
 
 pub(super) struct StrategyStartIdentitiesFormController {
     input: ComposedInput<(
-        Field<TextInput<DefaultTextInputParser<u8>>>,
+        Field<TextInput<DefaultTextInputParser<u16>>>,
         Field<TextInput<DefaultTextInputParser<u8>>>,
         Field<SelectInput<String>>,
     )>,


### PR DESCRIPTION
Can register a DPNS domain for an Identity in the Identity screen.

This works for broadcasting, but broadcast_and_wait isn't working.

Note DPNS names for contracts aren't supported in Platform yet.