### PR TITLE
fix: wallet was required in env file to start tui

### DIFF
--- a/src/backend/state.rs
+++ b/src/backend/state.rs
@@ -461,10 +461,10 @@ impl AppState {
             return state;
         };
 
-        if let Some(private_key) = &config.wallet_private_key {
-            let wallet_state = &app_state.loaded_wallet;
-            add_wallet_by_private_key(&wallet_state, private_key).await;
-        }
+        // if let Some(private_key) = &config.wallet_private_key {
+        //     let wallet_state = &app_state.loaded_wallet;
+        //     add_wallet_by_private_key(&wallet_state, private_key).await;
+        // }
 
         // Load supporting contracts
         let platform_version = PlatformVersion::get(CURRENT_PROTOCOL_VERSION).unwrap();

--- a/src/backend/state.rs
+++ b/src/backend/state.rs
@@ -461,6 +461,12 @@ impl AppState {
             return state;
         };
 
+        // Load wallet by private key, overriding the state file
+        if let Some(private_key) = &config.wallet_private_key {
+            let wallet_state = &app_state.loaded_wallet;
+            add_wallet_by_private_key(&wallet_state, private_key).await;
+        }
+
         // Load supporting contracts
         let platform_version = PlatformVersion::get(CURRENT_PROTOCOL_VERSION).unwrap();
         let mut supporting_contracts = BTreeMap::new();

--- a/src/backend/state.rs
+++ b/src/backend/state.rs
@@ -461,11 +461,6 @@ impl AppState {
             return state;
         };
 
-        // if let Some(private_key) = &config.wallet_private_key {
-        //     let wallet_state = &app_state.loaded_wallet;
-        //     add_wallet_by_private_key(&wallet_state, private_key).await;
-        // }
-
         // Load supporting contracts
         let platform_version = PlatformVersion::get(CURRENT_PROTOCOL_VERSION).unwrap();
         let mut supporting_contracts = BTreeMap::new();


### PR DESCRIPTION
A bug was introduced where if you didn't have a state file and also didn't have a wallet private key specified in env file, the tui wouldn't start. This PR handles that error and allows the tui to start anyways.