### PR TITLE
fix: allow loading masternode identity without a loaded wallet

### DIFF
--- a/src/ui/views/identities.rs
+++ b/src/ui/views/identities.rs
@@ -331,9 +331,7 @@ impl ScreenController for IdentitiesScreenController {
             Event::Key(KeyEvent {
                 code: Key::Char('m'),
                 modifiers: KeyModifiers::NONE,
-            }) if self.wallet_loaded => {
-                ScreenFeedback::Form(Box::new(LoadMasternodeIdentityFormController::new()))
-            }
+            }) => ScreenFeedback::Form(Box::new(LoadMasternodeIdentityFormController::new())),
 
             Event::Key(KeyEvent {
                 code: Key::Char('p'),


### PR DESCRIPTION
## Issue being fixed or feature implemented
Masternode identities couldn't be loaded without having a wallet loaded.

## What was done?
Removed check for loaded wallet when selecting the load mn identity option

## How Has This Been Tested?
Locally

## Breaking Changes
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed
